### PR TITLE
Version v1.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-redux-firebase",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Redux integration for Firebase. Comes with a Higher Order Component for use with React.",
   "main": "dist/index.js",
   "module": "src/index.js",

--- a/src/actions/auth.js
+++ b/src/actions/auth.js
@@ -184,27 +184,26 @@ export const init = (dispatch, firebase) => {
   if (firebase._.config.enableRedirectHandling) {
     firebase.auth().getRedirectResult()
       .then((authData) => {
-        if (!authData || !authData.user) {
-          return dispatch({ type: LOGOUT })
+        if (authData && authData.user) {
+          const { user } = authData
+
+          firebase._.authUid = user.uid
+          watchUserProfile(dispatch, firebase)
+
+          dispatchLogin(dispatch, user)
+
+          createUserProfile(
+            dispatch,
+            firebase,
+            user,
+            {
+              email: user.email,
+              displayName: user.providerData[0].displayName || user.email,
+              avatarUrl: user.providerData[0].photoURL,
+              providerData: user.providerData
+            }
+          )
         }
-        const { user } = authData
-
-        firebase._.authUid = user.uid
-        watchUserProfile(dispatch, firebase)
-
-        dispatchLogin(dispatch, user)
-
-        createUserProfile(
-          dispatch,
-          firebase,
-          user,
-          {
-            email: user.email,
-            displayName: user.providerData[0].displayName || user.email,
-            avatarUrl: user.providerData[0].photoURL,
-            providerData: user.providerData
-          }
-        )
       }).catch((error) => {
         dispatchLoginError(dispatch, error)
         return Promise.reject(error)

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -228,9 +228,6 @@ export const populatedDataToJS = (data, path, populates, notSetValue) => {
     return notSetValue
   }
 
-  if (!dataToJS(data, path, notSetValue)) {
-    return dataToJS(data, path)
-  }
   const populateObjs = getPopulateObjs(populates)
   // reduce array of populates to object of combined populated data
   return reduce(

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -176,6 +176,29 @@ export const dataToJS = (data, path, notSetValue) => {
 
   return data
 }
+
+/**
+ * @private
+ * @description Build child list based on populate
+ * @param {Map} data - Immutable Map to be converted to JS object (state.firebase)
+ * @param {Object} list - Path of parameter to load
+ * @param {Object} populate - Object with population settings
+ */
+export const buildChildList = (data, list, populate) =>
+  mapValues(list, (val, key) => {
+    let getKey = val
+     // Handle key: true lists
+    if (val === true) {
+      getKey = key
+    }
+    // Set to child under key if populate child exists
+    if (dataToJS(data, `${populate.root}/${getKey}`)) {
+      return dataToJS(data, `${populate.root}/${getKey}`)
+    }
+    // Populate child does not exist
+    return val === true ? val : getKey
+  })
+
 /**
  * @description Convert parameter under "data" path of Immutable Map to a
  * Javascript object with parameters populated based on populates array
@@ -188,13 +211,16 @@ export const dataToJS = (data, path, notSetValue) => {
  * import { connect } from 'react-redux'
  * import { firebaseConnect, helpers } from 'react-redux-firebase'
  * const { dataToJS } = helpers
+ * const populates = [{ child: 'owner', root: 'users' }]
  *
- * const fbWrapped = firebaseConnect(['/todos'])(App)
+ * const fbWrapped = firebaseConnect([
+ * { path: '/todos', populates } // load "todos" and matching "users" to redux
+ * ])(App)
  *
  * export default connect(({ firebase }) => ({
  *   // this.props.todos loaded from state.firebase.data.todos
  *   // each todo has child 'owner' populated from matching uid in 'users' root
- *   todos: populatedDataToJS(firebase, 'todos', [{ child: 'owner', root: 'users' }])
+ *   todos: populatedDataToJS(firebase, 'todos', populates)
  * }))(fbWrapped)
  */
 export const populatedDataToJS = (data, path, populates, notSetValue) => {
@@ -202,57 +228,47 @@ export const populatedDataToJS = (data, path, populates, notSetValue) => {
     return notSetValue
   }
 
-  const pathArr = `/data${fixPath(path)}`.split(/\//).slice(1)
-
-  if (data.getIn) {
-    if (!toJS(data.getIn(pathArr, notSetValue))) {
-      return toJS(data.getIn(pathArr))
-    }
-    const populateObjs = getPopulateObjs(populates)
-    // reduce array of populates to object of combined populated data
-    return reduce(
-      map(populateObjs, (p, obj) =>
-        // map values of list
-        mapValues(toJS(data.getIn(pathArr)), (child, i) => {
-          // no matching child parameter
-          if (!child[p.child]) {
-            return child
-          }
-          // populate child is key
-          if (isString(child[p.child])) {
-            if (toJS(data.getIn(['data', p.root, child[p.child]]))) {
-              return {
-                ...child,
-                [p.child]: toJS(data.getIn(['data', p.root, child[p.child]]))
-              }
-            }
-            // matching child does not exist
-            return child
-          }
-          // populate child list
-          return {
-            ...child,
-            [p.child]: mapValues(child[p.child], (val, key) => { // iterate of child list
-              let getKey = val
-               // Handle key: true lists
-              if (val === true) {
-                getKey = key
-              }
-              // Set to child under key if populate child exists
-              if (toJS(data.getIn(['data', p.root, getKey]))) {
-                return toJS(data.getIn(['data', p.root, getKey]))
-              }
-              // Populate child does not exist
-              return val === true ? val : getKey
-            })
-          }
-        })
-     ), (obj, v) =>
-      Object.assign({}, v, obj),
-     )
+  if (!dataToJS(data, path, notSetValue)) {
+    return dataToJS(data, path)
   }
-
-  return data
+  const populateObjs = getPopulateObjs(populates)
+  // reduce array of populates to object of combined populated data
+  return reduce(
+    map(populateObjs, (p, obj) => {
+      // single item with iterable child
+      if (dataToJS(data, path)[p.child]) {
+        return {
+          ...dataToJS(data, path),
+          [p.child]: buildChildList(data, dataToJS(data, path)[p.child], p)
+        }
+      }
+      // list with child param in each item
+      return mapValues(dataToJS(data, path), (child, i) => {
+        // no matching child parameter
+        if (!child[p.child]) {
+          return child
+        }
+        // populate child is key
+        if (isString(child[p.child])) {
+          if (dataToJS(data, `${p.root}/${child[p.child]}`)) {
+            return {
+              ...child,
+              [p.child]: dataToJS(data, `${p.root}/${child[p.child]}`)
+            }
+          }
+          // matching child does not exist
+          return child
+        }
+        // populate child list
+        return {
+          ...child,
+          [p.child]: buildChildList(data, child[p.child], p)
+        }
+      })
+    }), (obj, v) =>
+      // reduce data from all populates to one object
+      Object.assign({}, v, obj),
+   )
 }
 
 /**

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -121,7 +121,7 @@ export default (state = initialState, action = {}) => {
         auth: null,
         authError: null,
         profile: null,
-        isLoading: false,
+        isInitializing: false,
         data: {}
       })
 

--- a/src/utils/populate.js
+++ b/src/utils/populate.js
@@ -168,7 +168,7 @@ export const promisesForPopulate = (firebase, originalData, populatesIn) => {
   })
 
   // Return original data after population promises run
-  return Promise.all(promisesArray).then(d => results)
+  return Promise.all(promisesArray).then(() => results)
 }
 
 export default { promisesForPopulate }

--- a/test/unit/helpers.spec.js
+++ b/test/unit/helpers.spec.js
@@ -35,9 +35,11 @@ describe('Helpers:', () => {
     it('exists', () => {
       expect(helpers).to.respondTo('toJS')
     })
+
     it('handles non-immutable data', () => {
       expect(helpers.toJS(exampleData)).to.equal(exampleData)
     })
+
     it('handles immutable data', () => {
       expect(helpers.toJS(exampleState)).to.be.an.object
     })
@@ -47,22 +49,26 @@ describe('Helpers:', () => {
     it('exists', () => {
       expect(helpers).to.respondTo('pathToJS')
     })
+
     it('passes notSetValue', () => {
       expect(helpers.pathToJS(null, '/some', exampleData))
         .to
         .equal(exampleData)
     })
+
     it('gets data', () => {
       expect(helpers.pathToJS(exampleState, '/some', exampleData))
         .to
         .equal(exampleData)
     })
+
     it('gets meta (string key)', () => {
       expect(helpers.pathToJS(exampleState, 'timestamp/some/path'))
         .to
         .have
         .keys('test')
     })
+
     it('returns state if its not an immutable Map', () => {
       const fakeState = {}
       expect(helpers.pathToJS(fakeState, 'asdf'))
@@ -75,17 +81,20 @@ describe('Helpers:', () => {
     it('exists', () => {
       expect(helpers).to.respondTo('dataToJS')
     })
+
     it('passes notSetValue', () => {
       expect(helpers.dataToJS(null, '/some', exampleData))
         .to
         .equal(exampleData)
     })
+
     it('gets data from state', () => {
       const path = 'some'
       expect(helpers.dataToJS(exampleState, path, exampleData))
         .to
         .equal(exampleData.data[path])
     })
+
     it('returns state if its not an immutable Map', () => {
       const fakeState = { }
       expect(helpers.dataToJS(fakeState, 'asdf'))
@@ -98,22 +107,19 @@ describe('Helpers:', () => {
     it('exists', () => {
       expect(helpers).to.respondTo('populatedDataToJS')
     })
+
     it('passes notSetValue', () => {
       expect(helpers.populatedDataToJS(null, '/some', [], exampleData))
         .to
         .equal(exampleData)
     })
+
     it('returns undefined for non existant path', () => {
       expect(helpers.populatedDataToJS(exampleState, '/asdf', []))
         .to
         .equal(undefined)
     })
-    it('returns state if its not an immutable Map', () => {
-      const fakeState = { }
-      expect(helpers.populatedDataToJS(fakeState, 'asdf'))
-        .to
-        .equal(fakeState)
-    })
+
     it('returns unpopulated data for no populates', () => {
       const path = '/projects'
       expect(helpers.populatedDataToJS(exampleState, path, []))
@@ -185,16 +191,19 @@ describe('Helpers:', () => {
     it('exists', () => {
       expect(helpers).to.respondTo('customToJS')
     })
+
     it('handles non-immutable state', () => {
       expect(helpers.customToJS(exampleData, '/some', 'some'))
         .to
         .equal(exampleData)
     })
+
     it('passes notSetValue', () => {
       expect(helpers.customToJS(null, '/some', 'some', exampleData))
         .to
         .equal(exampleData)
     })
+
     it('passes custom data', () => {
       expect(helpers.customToJS(exampleState, '/some', 'snapshot'))
         .to
@@ -206,9 +215,11 @@ describe('Helpers:', () => {
     it('exists', () => {
       expect(helpers).to.respondTo('isLoaded')
     })
+
     it('defaults to true when no arguments passed', () => {
       expect(helpers.isLoaded()).to.be.true
     })
+
     it('returns true when is loaded', () => {
       expect(helpers.isLoaded('some')).to.be.true
     })
@@ -218,9 +229,11 @@ describe('Helpers:', () => {
     it('exists', () => {
       expect(helpers).to.respondTo('isEmpty')
     })
+
     it('returns false when not loaded', () => {
       expect(helpers.isEmpty('asdf')).to.be.false
     })
+
     it('returns true when is loaded', () => {
       expect(helpers.isEmpty([{}])).to.be.false
     })

--- a/test/unit/reducer.spec.js
+++ b/test/unit/reducer.spec.js
@@ -29,8 +29,7 @@ const exampleEmptyState = fromJS(emptyState)
 
 describe('reducer', () => {
   it('is a function', () => {
-    expect(firebaseStateReducer)
-      .to.be.a.function
+    expect(firebaseStateReducer).to.be.a.function
   })
 
   it('handles no initialState', () => {
@@ -109,7 +108,7 @@ describe('reducer', () => {
         auth: null,
         authError: null,
         profile: null,
-        isLoading: false,
+        isInitializing: false,
         data: {}
       }))
     })


### PR DESCRIPTION
* Single item with iterable child population now supported with `populatedDataToJS`
* `getRedirectResult` no longer calls dispatches `LOGOUT` on null response (fixes refresh issue with redux-auth-wrapper).
* `isLoading` typo corrected to `isInitalizing` in logout reducer case