### PR TITLE
Version v1.3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ addons:
     repo_token: $CODE_CLIMATE
 
 before_install:
-  - "npm install react firebase lodash redux react-redux"
+  - "npm install react redux react-redux"
 
 after_success:
   - npm install -g codeclimate-test-reporter
@@ -35,5 +35,4 @@ deploy:
   email: $NPM_EMAIL
   api_key: $NPM_TOKEN
   on:
-    tags: true
     branch: master

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -125,6 +125,7 @@ Similar to Firebase's `ref.createUser(credentials)` but with support for automat
 * `credentials` [**Object**](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)
   * `credentials.email` [**String**](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String) - User's email
   * `credentials.password` [**String**](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String) - User's password
+  * `credentials.signIn` [**String**](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String) - Whether or not to sign in when user is signing up (defaults to `true`)
 
 * `profile` [**Object**](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)
   * `profile.username` [**String**](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -161,7 +161,7 @@ firebase.logout()
 ```
 
 ## resetPassword(credentials)
-Calls Firebase's `ref.resetPassword(credentials)` then adds the output into redux state under `state.firebase.authError`
+Calls Firebase's `firebase.auth().resetPassword()`. If there is an error, it is added into redux state under `state.firebase.authError`, which can be loaded using `pathToJS(state.firebase, 'authError')`.
 
 ##### Examples
 
@@ -180,3 +180,36 @@ firebase.resetPassword({
 ##### Returns
   [**Promise**](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) with user's UID in case of success or the error otherwise.
   Always authenticate the new user in case of success
+
+## confirmPasswordReset(code, newPassword)
+Calls Firebase's `firebase.auth().confirmPasswordReset()`. If there is an error, it is added into redux state under `state.firebase.authError`, which can be loaded using `pathToJS(state.firebase, 'authError')`.
+
+##### Examples
+
+```js
+firebase.confirmPasswordReset('some reset code', 'myNewPassword')
+```
+
+##### Parameters
+  * `code` [**String**](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object) - Password reset code
+  * `newPassword` [**String**](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object) - New password to set for user
+
+##### Returns
+  [**Promise**](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)
+
+## verifyPasswordResetCode(code)
+Verify a password reset code from password reset email.
+
+Calls Firebase's `firebase.auth().verifyPasswordResetCode()`. If there is an error, it is added into redux state under `state.firebase.authError`, which can be loaded using `pathToJS(state.firebase, 'authError')`.
+
+##### Examples
+
+```js
+firebase.verifyPasswordResetCode('some reset code')
+```
+
+##### Parameters
+  * `code` [**String**](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object) - Password reset code
+
+##### Returns
+  [**Promise**](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) - Email associated with reset code

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-redux-firebase",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Redux integration for Firebase. Comes with a Higher Order Component for use with React.",
   "browser": "dist/react-redux-firebase.js",
   "main": "lib/index.js",

--- a/src/actions/auth.js
+++ b/src/actions/auth.js
@@ -429,6 +429,25 @@ export const confirmPasswordReset = (dispatch, firebase, code, password) => {
     })
 }
 
+/**
+ * @description Verify that password reset code is valid
+ * @param {Function} dispatch - Action dispatch function
+ * @param {Object} firebase - Internal firebase object
+ * @param {String} code - Password reset code
+ * @return {Promise} email - Email associated with reset code
+ * @private
+ */
+export const verifyPasswordResetCode = (dispatch, firebase, code) => {
+  dispatchLoginError(dispatch, null)
+  return firebase.auth()
+    .verifyPasswordResetCode(code)
+    .catch((err) => {
+      if (err) {
+        dispatchLoginError(dispatch, err)
+      }
+      return Promise.reject(err)
+    })
+}
 
 export default {
   dispatchLoginError,
@@ -442,5 +461,6 @@ export default {
   logout,
   createUser,
   resetPassword,
-  confirmPasswordReset
+  confirmPasswordReset,
+  verifyPasswordResetCode
 }

--- a/src/actions/auth.js
+++ b/src/actions/auth.js
@@ -338,11 +338,13 @@ export const createUser = (dispatch, firebase, { email, password, signIn }, prof
   return firebase.auth()
     .createUserWithEmailAndPassword(email, password)
     .then((userData) =>
-      // Login to newly created account if signIn flag is true
+      // Login to newly created account if signIn flag is not set to false
       firebase.auth().currentUser || (!!signIn && signIn === false)
-        ? createUserProfile(dispatch, firebase, userData, profile)
+        ? createUserProfile(dispatch, firebase, userData, profile || { email })
         : login(dispatch, firebase, { email, password })
-            .then(() => createUserProfile(dispatch, firebase, userData, profile || { email }))
+            .then(() =>
+              createUserProfile(dispatch, firebase, userData, profile || { email })
+            )
             .catch(err => {
               if (err) {
                 switch (err.code) {

--- a/src/compose.js
+++ b/src/compose.js
@@ -144,6 +144,9 @@ export default (fbConfig, otherConfig) => next =>
     const confirmPasswordReset = (code, password) =>
       authActions.confirmPasswordReset(dispatch, firebase, code, password)
 
+    const verifyPasswordResetCode = (code) =>
+      authActions.verifyPasswordResetCode(dispatch, firebase, code)
+
     firebase.helpers = {
       ref: path => Firebase.database().ref(path),
       set,
@@ -159,6 +162,7 @@ export default (fbConfig, otherConfig) => next =>
       createUser,
       resetPassword,
       confirmPasswordReset,
+      verifyPasswordResetCode,
       watchEvent,
       unWatchEvent,
       storage: () => Firebase.storage()


### PR DESCRIPTION
### Enhancements
* `confirmPasswordReset` action added from #74 (thanks @rpeterson)
* `verifyPasswordResetCode` action added
* If no profile is passed to `firebase.createUser`, email is used by default
* Docs updated with new methods
* Tests added for new auth actions