### PR TITLE
docs(example): remove refs from storage example

### DIFF
--- a/docs/storage.md
+++ b/docs/storage.md
@@ -92,7 +92,6 @@ export default class Uploader extends Component {
     const { firebase: { storage } } = this.props;
 
     const addTestFile = () => {
-      const {newTodo} = this.refs
       const storageRef = storage().ref()
       const fileRef = storageRef.child('test.txt')
       fileRef.putString('Some File Contents')


### PR DESCRIPTION
I deleted the line `const {newTodo} = this.refs` of the file string upload example because it seemed unnecessary to me.