### PR TITLE
Version v1.4.0 Beta 2

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,0 @@
-# Dependency directory
-node_modules
-
-# Logs
-*.log
-**/node_modules

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-redux-firebase",
-  "version": "1.4.0",
+  "version": "1.4.0-beta.2",
   "description": "Redux integration for Firebase. Comes with a Higher Order Component for use with React.",
   "browser": "dist/react-redux-firebase.js",
   "main": "lib/index.js",

--- a/tests/unit/compose.spec.js
+++ b/tests/unit/compose.spec.js
@@ -7,7 +7,11 @@ const reducer = sinon.spy()
 const generateCreateStore = (params) =>
   compose(composeFunc(
     params ? omit(fbConfig, params) : fbConfig,
-    { userProfile: 'users', enableLogging: false, enableRedirectHandling: false }
+    {
+      userProfile: 'users',
+      enableLogging: false,
+      enableRedirectHandling: false
+    }
   ))(createStore)
 const helpers = generateCreateStore()(reducer).firebase.helpers
 
@@ -37,13 +41,35 @@ describe('Compose', () => {
       helpers.set('test', {some: 'asdf'})
     )
 
+    describe('setWithMeta', () => {
+      it('accepts object', () =>
+        helpers.setWithMeta('test', {some: 'asdf'})
+      )
+      it('does not attach meta to string', () =>
+        // TODO: confirm that data set actually does not include meta
+        helpers.setWithMeta('test', 'asdd')
+      )
+    })
+
     describe('push', () =>
       helpers.push('test', {some: 'asdf'})
     )
 
+    describe('pushWithMeta', () => {
+      it('accepts object', () =>
+        helpers.pushWithMeta('test', {some: 'asdf'})
+      )
+    })
+
     describe('update', () =>
       helpers.update('test', {some: 'asdf'})
     )
+
+    describe('updateWithMeta', () => {
+      it('accepts object', () =>
+        helpers.updateWithMeta('test', {some: 'asdf'})
+      )
+    })
 
     describe('uniqueSet', () =>{
       // remove test root after test are complete


### PR DESCRIPTION
* fix using with yarn - `.npmignore` file removed so that `.yarn.lock` file will not be included in npm release (only files listed in package file `files` property)
* `pushWithMeta`, `setWithMeta`, and `updateWithMeta` methods added - write to firebase with createdAt/updatedAt and createdBy/updatedBy