### PR TITLE
Fix spelling on connect documentation

### DIFF
--- a/docs/api/connect.md
+++ b/docs/api/connect.md
@@ -33,7 +33,7 @@ const fbWrapped = firebaseConnect([
 // pass todos list from redux as this.props.todosList
 export default connect(({ firebase }) => ({
   todosList: dataToJS(firebase, 'todos'),
-  profile: pathToJS(firebase, 'profile'), // pass profile data as this.props.proifle
+  profile: pathToJS(firebase, 'profile'), // pass profile data as this.props.profile
   auth: pathToJS(firebase, 'auth') // pass auth data as this.props.auth
 }))(fbWrapped)
 ```


### PR DESCRIPTION
### Description

Update a simple spelling mistake

### Check List

- [x] All tests passing
- [x] Docs updated with any changes or examples
