### PR TITLE
Allow to use different stores in firebaseConnect

### DIFF
--- a/src/connect.js
+++ b/src/connect.js
@@ -31,7 +31,7 @@ import { getEventsFromInput, createCallable } from './utils'
  *   auth: pathToJS(firebase, 'auth') // pass auth data as this.props.auth
  * }))(fbWrapped)
  */
-export default (dataOrFn = []) => WrappedComponent => {
+export const createFirebaseConnect = (storeKey = 'store') => (dataOrFn = []) => WrappedComponent => {
   class FirebaseConnect extends Component {
     constructor (props, context) {
       super(props, context)
@@ -40,11 +40,11 @@ export default (dataOrFn = []) => WrappedComponent => {
     }
 
     static contextTypes = {
-      store: PropTypes.object.isRequired
+      [storeKey]: PropTypes.object.isRequired
     };
 
     componentWillMount () {
-      const { firebase, dispatch } = this.context.store
+      const { firebase, dispatch } = this.context[storeKey]
 
       // Allow function to be passed
       const inputAsFunc = createCallable(dataOrFn)
@@ -93,3 +93,5 @@ export default (dataOrFn = []) => WrappedComponent => {
 
   return hoistStatics(FirebaseConnect, WrappedComponent)
 }
+
+export default createFirebaseConnect()


### PR DESCRIPTION
### Description
It allow to use more than one firebase app by using separate store for each one and connect components to different stores.

### Questions
- Will a new version need to be released or is this a docs change? **YES**
- Which version should this be published as a part of? **ASAP**
- Does this impact the external API? **YES**
- Will it need to be a breaking change? **NO**

### Check List
- [-] All tests passing
- [-] Docs updated with any changes or examples
- [-] Added tests to ensure feature(s) work properly

### Relevant Issues
* [#29](https://github.com/prescottprue/react-redux-firebase/issues/29)