### PR TITLE
Don't mix import/export with module.exports

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -156,13 +156,3 @@ export default {
   metaParams,
   paramSplitChar
 }
-
-module.exports = {
-  defaultJWTProps,
-  actionTypes,
-  defaultConfig,
-  supportedAuthProviders,
-  defaultInitProps,
-  metaParams,
-  paramSplitChar
-}


### PR DESCRIPTION
### Description
Webpack 2 doesn't allow to mix import/export with module.exports.
This forbids to use src in webpack, which is required for dead code elimination (tree shaking) to work.

### Questions
- Will a new version need to be released or is this a docs change? **YES**
- Which version should this be published as a part of? **ASAP**
- Does this impact the external API? **NO**
- Will it need to be a breaking change? **NO**

### Check List
- [ ] All tests passing
- [ ] Docs updated with any changes or examples
- [ ] Added tests to ensure feature(s) work properly

### Relevant Issues
<!-- List Relevant Issues here like so:
* [#1](https://github.com/prescottprue/react-redux-firebase/issues/#1)
-->