### PR TITLE
fix: unwatch events with same parameters as original watch

### DIFF
--- a/src/actions/query.js
+++ b/src/actions/query.js
@@ -172,8 +172,10 @@ export const watchEvent = (firebase, dispatch, { type, path, populates, queryPar
  * @param {String} event - Event for which to remove the watcher
  * @param {String} path - Path of watcher to remove
  */
-export const unWatchEvent = (firebase, dispatch, event, path, queryId = undefined) =>
-    unsetWatcher(firebase, dispatch, event, path, queryId)
+export const unWatchEvent = (firebase, dispatch, { type, path, storeAs, queryId = undefined }) => {
+  const watchPath = !storeAs ? path : `${path}@${storeAs}`
+  unsetWatcher(firebase, dispatch, type, watchPath, queryId)
+}
 
 /**
  * @description Add watchers to a list of events
@@ -192,8 +194,8 @@ export const watchEvents = (firebase, dispatch, events) =>
  * @param {Array} events - List of events for which to remove watchers
  */
 export const unWatchEvents = (firebase, dispatch, events) =>
-    events.forEach(event =>
-      unWatchEvent(firebase, dispatch, event.type, event.path)
-    )
+  events.forEach(event =>
+    unWatchEvent(firebase, dispatch, event)
+  )
 
 export default { watchEvents, unWatchEvents }

--- a/tests/unit/actions/query.spec.js
+++ b/tests/unit/actions/query.spec.js
@@ -49,7 +49,7 @@ describe('Actions: Query', () => {
       expect(unWatchEvent).to.be.a.function
     })
     it('runs given basic params', () => {
-      expect(unWatchEvent(firebase, dispatch, 'once', 'projects')).to.be.a.function
+      expect(unWatchEvent(firebase, dispatch, { type: 'once', path: 'projects' })).to.be.a.function
     })
   })
 


### PR DESCRIPTION
### Description

`unWatchEvent` was not passing the correct `queryId` or `path` param (i.e. matching params passed to `watchEvent`), causing internal `firebase._.watchers` to continuously grow due to `unsetWatcher` being unable to resolve the watcher. This manifests as open firebase subscriptions continuing to grow, even when then the component that issued the query that opened the subscription is unmounted.

PR fixes the passed params so that `unsetWatcher` is able to clean up the watchers on unmount. Best test case for this is probably to compare that `firebase._.watchers` map after component mount and component unmount, and compare this PR against behavior on master.

### Questions
<!-- Only include questions that apply to your pull request -->
- Will a new version need to be released or is this a docs change?
  New version.
  - Which version should this be published as a part of? ("ASAP", "no idea", and specific version number)
  ASAP in my opinion - bug results in open firebase subscriptions only increasing, never decreasing. Long lived apps may end up resource or memory starved as the number of subscriptions grow.

- Does this impact the external API?
Nope.
  - Will it need to be a breaking change?
Depends, some users may be accidentally depending on the current behavior of not re-querying a previously watched route.

### Check List

- [x] All tests passing
- [x] Docs updated with any changes or examples
- [x] Added tests to ensure feature(s) work properly

### Relevant Issues
N / A
