### PR TITLE
fix(examples/complete/material-ui): project showDelete always false

### DIFF
--- a/examples/complete/material/src/routes/Projects/containers/ProjectsContainer.js
+++ b/examples/complete/material/src/routes/Projects/containers/ProjectsContainer.js
@@ -107,7 +107,7 @@ export default class Projects extends Component {
                    onCollabClick={this.collabClick}
                    onSelect={() => this.context.router.push(`${LIST_PATH}/${key}`)}
                    onDelete={() => this.deleteProject(key)}
-                   showDelete={auth && project.owner && project.owner.uid === auth.uid}
+                   showDelete={auth && project.createdBy && project.createdBy.uid === auth.uid}
                  />
               ))
           }


### PR DESCRIPTION
### Description

Fixes an issue in the material example where the delete button would never display.

### Check List

- [ ] All tests passing
- [ ] Docs updated with any changes or examples
- [ ] Added tests to ensure feature(s) work properly