### PR TITLE
[v2.0.0] fix(getFirebase): expose getFirebase

### DIFF
--- a/src/compose.js
+++ b/src/compose.js
@@ -7,6 +7,8 @@ import { defaultConfig } from './constants'
 import { validateConfig } from './utils'
 import { authActions } from './actions'
 
+let firebaseInstance
+
 /**
  * @name reactReduxFirebase
  * @external
@@ -88,8 +90,6 @@ export default (fbConfig, otherConfig) => next =>
     const store = next(reducer, initialState, middleware)
     const { dispatch } = store
 
-    let firebaseInstance
-
     // handle firebase instance being passed in as first argument
     if (typeof fbConfig.initializeApp === 'function') {
       firebaseInstance = createFirebaseInstance(fbConfig, otherConfig, dispatch)
@@ -112,3 +112,49 @@ export default (fbConfig, otherConfig) => next =>
 
     return store
   }
+
+/**
+ * @external
+ * @description Expose Firebase instance created internally. Useful for
+ * integrations into external libraries such as redux-thunk and redux-observable.
+ * @example <caption>redux-thunk integration</caption>
+ * import { applyMiddleware, compose, createStore } from 'redux';
+ * import thunk from 'redux-thunk';
+ * import { reactReduxFirebase } from 'react-redux-firebase';
+ * import makeRootReducer from './reducers';
+ * import { getFirebase } from 'react-redux-firebase';
+ *
+ * const fbConfig = {} // your firebase config
+ *
+ * const store = createStore(
+ *   makeRootReducer(),
+ *   initialState,
+ *   compose(
+ *     applyMiddleware([
+ *       // Pass getFirebase function as extra argument
+ *       thunk.withExtraArgument(getFirebase)
+ *     ]),
+ *     reactReduxFirebase(fbConfig)
+ *   )
+ * );
+ * // then later
+ * export const addTodo = (newTodo) =>
+ *  (dispatch, getState, getFirebase) => {
+ *    const firebase = getFirebase()
+ *    firebase
+ *      .push('todos', newTodo)
+ *      .then(() => {
+ *        dispatch({ type: 'SOME_ACTION' })
+ *      })
+ * };
+ *
+ */
+export const getFirebase = () => {
+  // TODO: Handle recieveing config and creating firebase instance if it doesn't exist
+  /* istanbul ignore next: Firebase instance always exists during tests */
+  if (!firebaseInstance) {
+    throw new Error('Firebase instance does not yet exist. Check your compose function.') // eslint-disable-line no-console
+  }
+  // TODO: Create new firebase here with config passed in
+  return firebaseInstance
+}

--- a/src/createFirebaseInstance.js
+++ b/src/createFirebaseInstance.js
@@ -1,8 +1,6 @@
 import { isObject } from 'lodash'
 import { authActions, queryActions, storageActions } from './actions'
 
-let firebaseInstance
-
 export const createFirebaseInstance = (firebase, configs, dispatch) => {
   // Enable Logging based on config
   if (configs.enableLogging) {
@@ -240,8 +238,8 @@ export const createFirebaseInstance = (firebase, configs, dispatch) => {
    * @param {String} storeAs - Name of listener results within redux store
    * @return {Promise}
    */
-  const unWatchEvent = (eventName, eventPath, queryId = undefined) =>
-    queryActions.unWatchEvent(instance, dispatch, eventName, eventPath, queryId)
+  const unWatchEvent = (type, path, queryId = undefined) =>
+    queryActions.unWatchEvent(instance, dispatch, { type, path, queryId })
 
   /**
    * @description Logs user into Firebase. For examples, visit the [auth section](/docs/auth.md)
@@ -304,6 +302,35 @@ export const createFirebaseInstance = (firebase, configs, dispatch) => {
     authActions.verifyPasswordResetCode(dispatch, instance, code)
 
   /**
+   * @description Update user profile
+   * @param {Object} profile - Profile data to place in new profile
+   * @return {Promise}
+   * @private
+   */
+  const updateProfile = (profileUpdate) =>
+    authActions.updateProfile(dispatch, instance, profileUpdate)
+
+  /**
+   * @description Update Auth Object
+   * @param {Object} authUpdate - Update to be auth object
+   * @param {Boolean} updateInProfile - Update in profile
+   * @return {Promise}
+   * @private
+   */
+  const updateAuth = (authUpdate, updateInProfile) =>
+    authActions.updateAuth(dispatch, instance, authUpdate, updateInProfile)
+
+  /**
+   * @description Update user's email
+   * @param {String} newEmail - Update to be auth object
+   * @param {Boolean} updateInProfile - Update in profile
+   * @return {Promise}
+   * @private
+   */
+  const updateEmail = (newEmail, updateInProfile) =>
+    authActions.updateEmail(dispatch, instance, newEmail, updateInProfile)
+
+  /**
    * @name ref
    * @description Firebase ref function
    * @return {database.Reference}
@@ -338,6 +365,9 @@ export const createFirebaseInstance = (firebase, configs, dispatch) => {
       updateWithMeta,
       login,
       logout,
+      updateAuth,
+      updateEmail,
+      updateProfile,
       uploadFile,
       uploadFiles,
       deleteFile,
@@ -349,50 +379,4 @@ export const createFirebaseInstance = (firebase, configs, dispatch) => {
       unWatchEvent
     }
   }
-}
-
-/**
- * @external
- * @description Expose Firebase instance created internally. Useful for
- * integrations into external libraries such as redux-thunk and redux-observable.
- * @example <caption>redux-thunk integration</caption>
- * import { applyMiddleware, compose, createStore } from 'redux';
- * import thunk from 'redux-thunk';
- * import { reactReduxFirebase } from 'react-redux-firebase';
- * import makeRootReducer from './reducers';
- * import { getFirebase } from 'react-redux-firebase';
- *
- * const fbConfig = {} // your firebase config
- *
- * const store = createStore(
- *   makeRootReducer(),
- *   initialState,
- *   compose(
- *     applyMiddleware([
- *       // Pass getFirebase function as extra argument
- *       thunk.withExtraArgument(getFirebase)
- *     ]),
- *     reactReduxFirebase(fbConfig)
- *   )
- * );
- * // then later
- * export const addTodo = (newTodo) =>
- *  (dispatch, getState, getFirebase) => {
- *    const firebase = getFirebase()
- *    firebase
- *      .push('todos', newTodo)
- *      .then(() => {
- *        dispatch({ type: 'SOME_ACTION' })
- *      })
- * };
- *
- */
-export const getFirebase = () => {
-  // TODO: Handle recieveing config and creating firebase instance if it doesn't exist
-  /* istanbul ignore next: Firebase instance always exists during tests */
-  if (!firebaseInstance) {
-    throw new Error('Firebase instance does not yet exist. Check your compose function.') // eslint-disable-line no-console
-  }
-  // TODO: Create new firebase here with config passed in
-  return firebaseInstance
 }

--- a/tests/unit/compose.spec.js
+++ b/tests/unit/compose.spec.js
@@ -1,6 +1,7 @@
 import { omit } from 'lodash'
 import { createStore, combineReducers, compose } from 'redux'
-import composeFunc from '../../src/compose'
+import composeFunc, { getFirebase } from '../../src/compose'
+import { login } from '../../src/actions/auth'
 
 const exampleData = { data: { some: 'data' } }
 const reducer = sinon.spy()
@@ -14,7 +15,10 @@ const generateCreateStore = (params) =>
       enableRedirectHandling: false
     }
   ))(createStore)
-const helpers = generateCreateStore()(reducer).firebase.helpers
+
+generateCreateStore()(reducer)
+
+const helpers = getFirebase().helpers
 
 describe('Compose', () => {
   it('is a function', () => {
@@ -111,14 +115,14 @@ describe('Compose', () => {
       helpers.remove('test')
     )
 
-    describe.skip('watchEvent', () => {
+    describe('watchEvent', () => {
       it('starts watcher', () => {
         helpers.watchEvent('value', 'test')
       })
     })
 
-    describe.skip('unWatchEvent', () => {
-      it.skip('unWatchesEvent', () =>
+    describe('unWatchEvent', () => {
+      it('unWatchesEvent', () =>
         helpers.unWatchEvent('value', 'test')
       )
     })
@@ -218,7 +222,7 @@ describe('Compose', () => {
     })
   })
 
-  describe.skip('getFirebase', () => {
+  describe('getFirebase', () => {
     it('exports firebase instance', () => {
       expect(getFirebase()).to.be.an.object
     })


### PR DESCRIPTION
### Description

Make `getFirebase` properly exposed as it is in 1.x
Added functions:  `updateAuth`, `updateEmail`, and `updateProfile` to `firebaseInstance`.

### Check List

- [X] `compose.spec.js` fixed an passing
- [X] Docs moved

### Relevant Issues

`getFirebase` is undefined. I can't use `thunk` anymore.