### PR TITLE
[v2.0.0] fix(initialize): Check that 'database' is a function instead of 'initializeApp'

### DIFF
--- a/src/compose.js
+++ b/src/compose.js
@@ -91,7 +91,7 @@ export default (fbConfig, otherConfig) => next =>
     let firebaseInstance
 
     // handle firebase instance being passed in as first argument
-    if (typeof fbConfig.initializeApp === 'function') {
+    if (typeof fbConfig.database === 'function') {
       firebaseInstance = createFirebaseInstance(fbConfig, otherConfig, dispatch)
     } else {
       // Combine all configs


### PR DESCRIPTION
Check that 'database' is a function instead of 'initializeApp'. This allows for passing in of pre-initialized firebase instances (like react-native-firebase).

### Description

<!-- Write Your Description Here ^  -->
<!-- Some things that may be of interest to address:
- Will a new version need to be released or is this a docs change?
- Which version should this be published as a part of? ("ASAP", "no idea", and specific version number)
- Does this impact the external API?
- Will it need to be a breaking change? -->

When using react-native-firebase:

```
import firebase from 'react-native-firebase'
import { reactReduxFirebase } from 'react-redux-firebase'

const FBConfig = {
  debug: false,
  persistence: true
}

const reactReduxFBConfig = {
  enableLogging: false,
  userProfile: 'users',
}

const firebaseApp = firebase.initializeApp(FBConfig)

compose(
reactReduxFirebase(firebaseApp, reactReduxFBConfig)
...
)
```

Returns the error: **databaseURL is a required config parameter for react-redux-firebase**

In this case, react-redux-firebase tries to parse firebaseApp as a config object, because it no longer contains the initalizeApp function. This PR addresses that. 

One concern I still have though- I am not sure whether the database() function exists on firebase instances with no database configured. So there may be a better way to address this.

### Check List
If not relevant to pull request, check off as complete

- [ ] All tests passing
- [ ] Docs updated with any changes or examples
- [ ] Added tests to ensure feature(s) work properly

### Relevant Issues
<!-- List Relevant Issues here -->
<!-- * #1 -->
