### PR TITLE
Version v2.0.0 Alpha 7

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -2,6 +2,7 @@
   "presets": ["es2015", "react"],
   "plugins": [
     "lodash",
+    "add-module-exports",
     "transform-object-rest-spread",
     "transform-object-assign",
     "transform-class-properties"
@@ -11,8 +12,7 @@
       "comments": false
     },
     "commonjs": {
-      "comments": false,
-      "plugins": ["transform-es2015-modules-commonjs"]
+      "comments": false
     },
     "test": {
       "plugins": ["transform-decorators-legacy"]

--- a/.npmignore
+++ b/.npmignore
@@ -14,3 +14,8 @@ book.json
 CNAME
 .github
 yarn.lock
+.travis.yml
+CODE_OF_CONDUCT.md
+CHANGELOG.md
+.codeclimate.yml
+PATRONS.md

--- a/examples/complete/react-native/package.json
+++ b/examples/complete/react-native/package.json
@@ -14,7 +14,7 @@
     "react-native": "0.42.0",
     "react-native-google-signin": "0.9.0",
     "react-redux": "^5.0.3",
-    "react-redux-firebase": "^2.0.0-alpha.4",
+    "react-redux-firebase": "^2.0.0-alpha.7",
     "redux": "^3.6.0"
   },
   "devDependencies": {

--- a/examples/complete/react-native/yarn.lock
+++ b/examples/complete/react-native/yarn.lock
@@ -1187,10 +1187,6 @@ errorhandler@~1.4.2:
     accepts "~1.3.0"
     escape-html "~1.0.3"
 
-es6-promise@^4.1.0:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.1.1.tgz#8811e90915d9a0dba36274f0b242dbda78f9c92a"
-
 escape-html@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.2.tgz#d77d32fa98e38c2f41ae85e9278e0e0e6ba1022c"
@@ -2407,11 +2403,10 @@ react-proxy@^1.1.7:
     lodash "^4.6.1"
     react-deep-force-update "^1.0.0"
 
-react-redux-firebase@^2.0.0-alpha.4:
-  version "2.0.0-alpha.4"
-  resolved "https://registry.yarnpkg.com/react-redux-firebase/-/react-redux-firebase-2.0.0-alpha.4.tgz#b6e77b7d05ab1d6030d5663adf35db6ee8c7902c"
+react-redux-firebase@^2.0.0-alpha.7:
+  version "2.0.0-alpha.6"
+  resolved "https://registry.yarnpkg.com/react-redux-firebase/-/react-redux-firebase-2.0.0-alpha.7.tgz#87d55fca3d130ab13a6fd9c51da5aa8026beada4"
   dependencies:
-    es6-promise "^4.1.0"
     firebase "^4.1.3"
     hoist-non-react-statics "^1.2.0"
     jwt-decode "^2.2.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-redux-firebase",
-  "version": "2.0.0-alpha.6",
+  "version": "2.0.0-alpha.7",
   "description": "Redux integration for Firebase. Comes with a Higher Order Component for use with React.",
   "main": "lib/index.js",
   "module": "es/index.js",
@@ -71,9 +71,9 @@
     "babel-eslint": "^7.2.1",
     "babel-loader": "^6.4.1",
     "babel-plugin-lodash": "^3.2.11",
+    "babel-plugin-add-module-exports": "^0.2.1",
     "babel-plugin-transform-class-properties": "^6.23.0",
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
-    "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
     "babel-plugin-transform-object-assign": "^6.22.0",
     "babel-plugin-transform-object-rest-spread": "^6.23.0",
     "babel-plugin-transform-runtime": "^6.23.0",


### PR DESCRIPTION
* Reverted back to `add-module-exports` to fix issue with base level exports (breaking react-native example)
* More files added to `.npmignore` including:
  * .travis.yml
  * CODE_OF_CONDUCT.md
  * CHANGELOG.md
  * .codeclimate.yml
  * PATRONS.md