### PR TITLE
feat(firebaseConnect): expose wrapped component and displayName

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "immutable": "^3.8.1",
     "jwt-decode": "^2.2.0",
     "lodash": "^4.17.4",
-    "opencollective": "^1.0.3"
+    "opencollective": "^1.0.3",
+    "react-display-name": "^0.2.0"
   },
   "peerDependencies": {
     "react": "^0.14.6 || ^15.0.0"

--- a/src/connect.js
+++ b/src/connect.js
@@ -1,4 +1,5 @@
 import React, { Component, PropTypes } from 'react'
+import getDisplayName from 'react-display-name'
 import { isEqual } from 'lodash'
 import hoistStatics from 'hoist-non-react-statics'
 import { watchEvents, unWatchEvents } from './actions/query'
@@ -58,7 +59,7 @@ export default (dataOrFn = []) => WrappedComponent => {
       store: PropTypes.object.isRequired
     };
 
-    static displayName = `FirebaseConnect(${WrappedComponent.displayName}`;
+    static displayName = `FirebaseConnect(${getDisplayName(WrappedComponent)}`;
     static WrappedComponent = WrappedComponent;
 
     componentWillMount () {

--- a/src/connect.js
+++ b/src/connect.js
@@ -43,6 +43,9 @@ export default (dataOrFn = []) => WrappedComponent => {
       store: PropTypes.object.isRequired
     };
 
+    static displayName = `FirebaseConnect(${WrappedComponent.displayName}`;
+    static WrappedComponent = WrappedComponent;
+
     componentWillMount () {
       const { firebase, dispatch } = this.context.store
 


### PR DESCRIPTION
### Description

Adds two statics to a connected component:
- `WrappedComponent`, which is the original component. This is useful for testing without mocking out firebase.
- `displayName` is set to reveal what component is wrapped by FirebaseConnect. This makes debugging easier.

This will require a new version (presumably 1.4.4) but is purely additive and therefore should not break any existing code, unless people were relying on the previous behavior of `displayName`.

### Check List
If not relevant to pull request, check off as complete

- [x] All tests passing
- [ ] Docs updated with any changes or examples
- [ ] Added tests to ensure feature(s) work properly
