### PR TITLE
make notSetValue optional in typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -105,9 +105,9 @@ export interface listenerConfigFunc {
 
 export function buildChildList(data: any, list: any, p: any): any;
 
-export function customToJS(data: any, path: any, custom: any, notSetValue: any): any;
+export function customToJS(data: any, path: any, custom: any, notSetValue?: any): any;
 
-export function dataToJS(data: any, path: any, notSetValue: any): any;
+export function dataToJS(data: any, path: any, notSetValue?: any): any;
 
 export function firebase(...args: any[]): any;
 
@@ -123,11 +123,11 @@ export function isEmpty(data: any): any;
 
 export function isLoaded(...args: any[]): any;
 
-export function orderedToJS(data: any, path: any, notSetValue: any): any;
+export function orderedToJS(data: any, path: any, notSetValue?: any): any;
 
-export function pathToJS(data: any, path: any, notSetValue: any): any;
+export function pathToJS(data: any, path: any, notSetValue?: any): any;
 
-export function populatedDataToJS(data: any, path: any, populates: any, notSetValue: any): any;
+export function populatedDataToJS(data: any, path: any, populates: any, notSetValue?: any): any;
 
 export function reactReduxFirebase(fbConfig: ConfigObject, otherConfig: any, ...args: any[]): any;
 
@@ -188,9 +188,9 @@ export namespace getFirebase {
 export namespace helpers {
     function buildChildList(data: any, list: any, p: any): any;
 
-    function customToJS(data: any, path: any, custom: any, notSetValue: any): any;
+    function customToJS(data: any, path: any, custom: any, notSetValue?: any): any;
 
-    function dataToJS(data: any, path: any, notSetValue: any): any;
+    function dataToJS(data: any, path: any, notSetValue?: any): any;
 
     function fixPath(path: any): any;
 
@@ -198,11 +198,11 @@ export namespace helpers {
 
     function isLoaded(...args: any[]): any;
 
-    function orderedToJS(data: any, path: any, notSetValue: any): any;
+    function orderedToJS(data: any, path: any, notSetValue?: any): any;
 
-    function pathToJS(data: any, path: any, notSetValue: any): any;
+    function pathToJS(data: any, path: any, notSetValue?: any): any;
 
-    function populatedDataToJS(data: any, path: any, populates: any, notSetValue: any): any;
+    function populatedDataToJS(data: any, path: any, populates: any, notSetValue?: any): any;
 
     function toJS(data: any): any;
 


### PR DESCRIPTION
### Description

This PR modifies the typings and makes the fallback-value (`notSetValue`) optional in all methods. This makes it possible to use it with two parameters and the implicit fallback-value of `undefined`, e.g.  `dataToJS(firebase, 'todos')` instead of `dataToJS(firebase, 'todos', undefined)`.

The docs don't have to be changed as this usage is intended and already possible in plain JS. The example above is copied from the docs.

Because this API-change is backwards compatible, no major release is necessary. I recommend to include this into the upcoming `1.5.0` release.

### Check List
If not relevant to pull request, check off as complete

- [ ] All tests passing - Tests are failing with `Error: Cannot find module 'react-display-name'`. However I suspect this is a separate issue (also happens with the upstream-branch)
- [x] Docs updated with any changes or examples
- [x] Added tests to ensure feature(s) work properly