### PR TITLE
Initialize initialState

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ const createStoreWithFirebase = compose(
 )(createStore)
 
 // Create store with reducers and initial state
+const initialState = {};
 const store = createStoreWithFirebase(rootReducer, initialState)
 ```
 


### PR DESCRIPTION
### Description

If one is following the Readme it will get an error because initialState doesn't have a value. I just added a empty `initialState`
