### PR TITLE
[v2.0.0] feat(reducers): authError reducer to mirror authError state in v1

### DIFF
--- a/src/reducer.js
+++ b/src/reducer.js
@@ -216,6 +216,27 @@ export const authReducer = (state = { isLoaded: false, isEmpty: true }, action) 
 }
 
 /**
+ * Reducer for authError state. Changed by `LOGIN`, `LOGOUT`, `LOGIN_ERROR`, and
+ * `UNAUTHORIZED_ERROR` actions.
+ * @param  {Object} [state={}] - Current authError redux state
+ * @param  {Object} action - Object containing the action that was dispatched
+ * @param  {String} action.type - Type of action that was dispatched
+ * @return {Object} authError state after reduction
+ */
+export const authErrorReducer = (state = { isLoaded: false, isEmpty: true }, action) => {
+  switch (action.type) {
+    case LOGIN:
+    case LOGOUT:
+      return null
+    case LOGIN_ERROR:
+    case UNAUTHORIZED_ERROR:
+      return action.authError
+    default:
+      return state
+  }
+}
+
+/**
  * Reducer for profile state. Changed by `SET_PROFILE`, `LOGOUT`, and
  * `LOGIN_ERROR` actions.
  * @param  {Object} [state={isLoaded: false}] - Current profile redux state
@@ -257,7 +278,9 @@ export const profileReducer = (state = { isLoaded: false, isEmpty: true }, actio
  */
 export const errorsReducer = (state = [], action) => {
   switch (action.type) {
-    case UNAUTHORIZED_ERROR: return [...state, action.authError]
+    case LOGIN_ERROR:
+    case UNAUTHORIZED_ERROR:
+      return [...state, action.authError]
     case LOGOUT: return []
     default: return state
   }
@@ -359,6 +382,7 @@ export default combineReducers({
   data: dataReducer,
   ordered: orderedReducer,
   auth: authReducer,
+  authError: authErrorReducer,
   profile: profileReducer,
   listeners: listenersReducer,
   isInitializing: isInitializingReducer,

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -223,11 +223,11 @@ export const authReducer = (state = { isLoaded: false, isEmpty: true }, action) 
  * @param  {String} action.type - Type of action that was dispatched
  * @return {Object} authError state after reduction
  */
-export const authErrorReducer = (state = { isLoaded: false, isEmpty: true }, action) => {
+export const authErrorReducer = (state = {}, action) => {
   switch (action.type) {
     case LOGIN:
     case LOGOUT:
-      return null
+      return {}
     case LOGIN_ERROR:
     case UNAUTHORIZED_ERROR:
       return action.authError

--- a/tests/unit/reducer.spec.js
+++ b/tests/unit/reducer.spec.js
@@ -4,6 +4,7 @@ import { actionTypes } from '../../src/constants'
 
 const initialState = {
   auth: { isLoaded: false, isEmpty: true },
+  authError: {},
   profile: { isLoaded: false, isEmpty: true },
   isInitializing: false,
   errors: [],
@@ -230,15 +231,18 @@ describe('reducer', () => {
 
   describe('LOGIN_ERROR action', () => {
     it('sets state', () => {
+      const authError = { some: 'error' }
       expect(
         firebaseStateReducer(
           {},
-          { type: actionTypes.LOGIN_ERROR }
+          { type: actionTypes.LOGIN_ERROR, authError }
         )
       ).to.deep.equal({
         ...initialState,
         auth: { isLoaded: true, isEmpty: true },
-        profile: { isLoaded: true, isEmpty: true }
+        profile: { isLoaded: true, isEmpty: true },
+        errors: [ authError ],
+        authError
       })
     })
   })
@@ -264,7 +268,7 @@ describe('reducer', () => {
       const authError = { some: 'error' }
       action = { type: actionTypes.UNAUTHORIZED_ERROR, authError }
       expect(firebaseStateReducer({}, action))
-        .to.deep.equal({ ...initialState, errors: [authError] })
+        .to.deep.equal({ ...initialState, errors: [authError], authError })
     })
   })
 


### PR DESCRIPTION
### Description
V2 appears to have dropped the firebase.authError redux state present in v1.x. This PR adds it back to maintain better backwards compatibility.

### Check List
If not relevant to pull request, check off as complete

- [X] All tests passing
- [X] Docs updated with any changes or examples if applicable
- [X] Added tests to ensure new feature(s) work properly

### Relevant Issues

