### PR TITLE
fix(populate): Update to deep path roots do not work with population (v2.0.0)

### DIFF
--- a/src/reducer.js
+++ b/src/reducer.js
@@ -1,6 +1,6 @@
-import set from 'lodash/fp/set'
 import { actionTypes } from './constants'
 import { pick, omit } from 'lodash'
+import { flow, set, merge } from 'lodash/fp'
 
 const {
   START,
@@ -172,7 +172,10 @@ export const timestampsReducer = (state = {}, { type, path }) => {
 const createDataReducer = (actionKey = 'data') => (state = {}, action) => {
   switch (action.type) {
     case SET:
-      return set(getDotStrPath(action.path), action[actionKey], state)
+      return flow(
+        set(getDotStrPath(action.path), action[actionKey]),
+        merge(state)
+      )({})
     case NO_VALUE:
       return set(getDotStrPath(action.path), null, state)
     case LOGOUT:


### PR DESCRIPTION
### Description
This is an update to PR 224, which did not go far enough at deeply merging data into the redux state.

Note: lodash's merge function appears to do a deep clone of the merged objects, which is likely unnecessary and expensive here. It would be nice to avoid this but there is no obvious way to accomplish this with lodash so I'm leaving it for a later PR.

### Check List
If not relevant to pull request, check off as complete

- [X] All tests passing
- [X] Docs updated with any changes or examples if applicable
- [X] Added tests to ensure new feature(s) work properly

### Relevant Issues
#223
