### PR TITLE
feat(auth): make signInWithCredential not dependent on provider

### DIFF
--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -63,14 +63,14 @@ export const getLoginMethodAndParams = (firebase, { email, password, provider, t
     if (token) {
       throw new Error('provider with token no longer supported, use credential parameter instead')
     }
-    if (credential) {
-      return { method: 'signInWithCredential', params: [ credential ] }
-    }
     const authProvider = createAuthProvider(firebase, provider, scopes)
     if (type === 'popup') {
       return { method: 'signInWithPopup', params: [ authProvider ] }
     }
     return { method: 'signInWithRedirect', params: [ authProvider ] }
+  }
+  if (credential) {
+    return { method: 'signInWithCredential', params: [ credential ] }
   }
   if (token) {
     return { method: 'signInWithCustomToken', params: [ token ] }


### PR DESCRIPTION
At the moment, I am trying to [authenticate using a phone number](https://firebase.google.com/docs/auth/web/phone-auth) and using `const credential = firebase.auth.PhoneAuthProvider.credential(confirmationResult.verificationId, code);` as a method of retrieving a credential to authenticate. However, this method of authentication can not be achieved currently, because `phone` is not in the list of supported providers. Instead of adding `phone` to the list of supported providers, why don't we just make `signInWithCredential` not dependant on whether a provider name is provided. Because `signInWithCredential` doesn't require provider :)