### PR TITLE
fix(reducer): allow setting paths ending in numbers

### DIFF
--- a/src/reducer.js
+++ b/src/reducer.js
@@ -1,6 +1,6 @@
 import { actionTypes } from './constants'
 import { pick, omit } from 'lodash'
-import { flow, set, merge } from 'lodash/fp'
+import { flow, setWith, merge } from 'lodash/fp'
 
 const {
   START,
@@ -40,7 +40,7 @@ const getSlashStrPath = path => pathToArr(path).join('/')
  * @return {String} Path seperated with dots
  * @private
  */
-const getDotStrPath = path => pathToArr(path).join('.')
+export const getDotStrPath = path => pathToArr(path).join('.')
 
 /**
  * Combine reducers utility (abreveated version of redux's combineReducer).
@@ -173,11 +173,11 @@ const createDataReducer = (actionKey = 'data') => (state = {}, action) => {
   switch (action.type) {
     case SET:
       return flow(
-        set(getDotStrPath(action.path), action[actionKey]),
+        setWith(Object, getDotStrPath(action.path), action[actionKey]),
         merge(state)
       )({})
     case NO_VALUE:
-      return set(getDotStrPath(action.path), null, state)
+      return setWith(Object, getDotStrPath(action.path), null, state)
     case LOGOUT:
       // support keeping data when logging out - #125
       if (action.preserve) {

--- a/tests/unit/reducer.spec.js
+++ b/tests/unit/reducer.spec.js
@@ -1,6 +1,6 @@
-import { set } from 'lodash'
-import { firebaseStateReducer } from '../../src'
+import { setWith } from 'lodash/fp'
 import { actionTypes } from '../../src/constants'
+import firebaseStateReducer, { getDotStrPath } from '../../src/reducer'
 
 const initialState = {
   auth: { isLoaded: false, isEmpty: true },
@@ -33,7 +33,6 @@ let childDotPath
 let initialData = {}
 const newData = { some: 'val' }
 const profile = { email: 'test@test.com' }
-const getDotPath = path => path.split('/').join('.')
 
 describe('reducer', () => {
   it('is a function', () => {
@@ -55,7 +54,7 @@ describe('reducer', () => {
     childKey = 'abc'
     childPath = `${path}/${childKey}`
     action = {}
-    childDotPath = getDotPath(childPath)
+    childDotPath = getDotStrPath(childPath)
   })
 
   // TODO: Do not write empty path to state
@@ -135,18 +134,29 @@ describe('reducer', () => {
         })
     })
 
+    it('sets data to state under paths that end in a number', () => {
+      action = { type: actionTypes.SET, path: 'test/123', data: exampleData }
+      expect(firebaseStateReducer({}, action).data)
+        .to.deep.equal({
+          ...initialState.data,
+          test: {
+            123: exampleData
+          }
+        })
+    })
+
     it('sets data to path with already existing value of null', () => {
       initialData = { data: { test: { [childKey]: null } } }
       action = { type: actionTypes.SET, path: childPath, data: newData }
       expect(firebaseStateReducer(initialData, action).data)
-        .to.deep.equal(set({}, childDotPath, newData))
+        .to.deep.equal(setWith(Object, childDotPath, newData, {}))
     })
 
     it('sets data to path with already existing parent of null', () => {
       initialData = { data: { test: null } }
       action = { type: actionTypes.SET, path: childPath, data: exampleData }
       expect(firebaseStateReducer(initialData, action).data)
-        .to.deep.equal(set({}, childDotPath, exampleData))
+        .to.deep.equal(setWith(Object, childDotPath, exampleData, {}))
     })
   })
 


### PR DESCRIPTION
Fixes #228, tests added

`_.set` does not respect numeric object keys.  Use `_.setWith` instead:

```js
const path = getDotStrPath('/analyses/123')  // => 'analyses.123'

_.set(path, { data: true }, {})              // => { analyses: [ undefined x 123 ] }

_.setWith(Object, path, { data: true }, {})  // => { analyses: { 123: { data: true } } }
```

There are many [lodash issues](https://github.com/lodash/lodash/issues?utf8=%E2%9C%93&q=is%3Aissue%20set%20number%20is%3Aclosed%20) and [SO posts](https://www.google.com/search?safe=active&biw=1439&bih=799&q=site%3Astackoverflow.com+lodash+set+number&oq=site%3Astackoverflow.com+lodash+set+number&gs_l=psy-ab.3...2213.2450.0.2572.4.4.0.0.0.0.0.0..0.0....0...1.1.64.psy-ab..4.0.0.ZlLLR7chKyY) about this bizarre design decision but it looks like it is not likely to be changed.