### PR TITLE
fix(reducer):  MERGE action added and SET action to reverted to v1 behavior

### DIFF
--- a/src/actions/query.js
+++ b/src/actions/query.js
@@ -12,6 +12,7 @@ import {
 const {
   START,
   SET,
+  MERGE,
   NO_VALUE,
   UNAUTHORIZED_ERROR,
   ERROR
@@ -143,7 +144,7 @@ export const watchEvent = (firebase, dispatch, { type, path, populates, queryPar
           // populate after all data is in redux (Issue #121)
           forEach(results, (result, path) => {
             dispatch({
-              type: SET,
+              type: MERGE,
               path,
               data: result
             })

--- a/src/constants.js
+++ b/src/constants.js
@@ -13,6 +13,7 @@ export const actionsPrefix = '@@reactReduxFirebase'
  * @description Object containing all action types
  * @property {String} START - `@@reactReduxFirebase/START`
  * @property {String} SET - `@@reactReduxFirebase/SET`
+ * @property {String} MERGE - `@@reactReduxFirebase/MERGE`
  * @property {String} SET_PROFILE - `@@reactReduxFirebase/SET_PROFILE`
  * @property {String} LOGIN - `@@reactReduxFirebase/LOGIN`
  * @property {String} LOGOUT - `@@reactReduxFirebase/LOGOUT`
@@ -48,6 +49,7 @@ export const actionsPrefix = '@@reactReduxFirebase'
 export const actionTypes = {
   START: `${actionsPrefix}/START`,
   SET: `${actionsPrefix}/SET`,
+  MERGE: `${actionsPrefix}/MERGE`,
   SET_PROFILE: `${actionsPrefix}/SET_PROFILE`,
   LOGIN: `${actionsPrefix}/LOGIN`,
   LOGOUT: `${actionsPrefix}/LOGOUT`,

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -1,6 +1,6 @@
 import { actionTypes } from './constants'
-import { pick, omit } from 'lodash'
-import { flow, setWith, merge } from 'lodash/fp'
+import { pick, omit, get } from 'lodash'
+import { setWith, assign } from 'lodash/fp'
 
 const {
   START,
@@ -172,10 +172,9 @@ export const timestampsReducer = (state = {}, { type, path }) => {
 const createDataReducer = (actionKey = 'data') => (state = {}, action) => {
   switch (action.type) {
     case SET:
-      return flow(
-        setWith(Object, getDotStrPath(action.path), action[actionKey]),
-        merge(state)
-      )({})
+      const previousData = get(state, getDotStrPath(action.path), {})
+      const mergedData = assign(previousData, action[actionKey])
+      return setWith(Object, getDotStrPath(action.path), mergedData, state)
     case NO_VALUE:
       return setWith(Object, getDotStrPath(action.path), null, state)
     case LOGOUT:

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -6,6 +6,7 @@ const {
   START,
   SET,
   SET_PROFILE,
+  MERGE,
   LOGIN,
   LOGOUT,
   LOGIN_ERROR,
@@ -160,8 +161,8 @@ export const timestampsReducer = (state = {}, { type, path }) => {
 
 /**
  * Creates reducer for data state. Used to create data and ordered reducers.
- * Changed by `SET` or `SET_ORDERED` (if actionKey === 'ordered'),`NO_VALUE`,
- * and `LOGOUT` actions.
+ * Changed by `SET` or `SET_ORDERED` (if actionKey === 'ordered'), `MERGE`,
+ * `NO_VALUE`, and `LOGOUT` actions.
  * @param  {Object} [state={}] - Current data redux state
  * @param  {Object} action - Object containing the action that was dispatched
  * @param  {String} action.type - Type of action that was dispatched
@@ -172,6 +173,8 @@ export const timestampsReducer = (state = {}, { type, path }) => {
 const createDataReducer = (actionKey = 'data') => (state = {}, action) => {
   switch (action.type) {
     case SET:
+      return setWith(Object, getDotStrPath(action.path), action[actionKey], state)
+    case MERGE:
       const previousData = get(state, getDotStrPath(action.path), {})
       const mergedData = assign(previousData, action[actionKey])
       return setWith(Object, getDotStrPath(action.path), mergedData, state)

--- a/tests/unit/reducer.spec.js
+++ b/tests/unit/reducer.spec.js
@@ -153,7 +153,6 @@ describe('reducer', () => {
           ...initialState.data,
           test: {
             [childKey]: {
-              foo1: 'bar1',
               foo2: 'bar2'
             }
           }
@@ -168,7 +167,6 @@ describe('reducer', () => {
           ...initialState.data,
           test: {
             [childKey]: {
-              123: 'bar1',
               124: 'bar2'
             }
           }
@@ -185,6 +183,78 @@ describe('reducer', () => {
     it('sets data to path with already existing parent of null', () => {
       initialData = { data: { test: null } }
       action = { type: actionTypes.SET, path: childPath, data: exampleData }
+      expect(firebaseStateReducer(initialData, action).data)
+        .to.deep.equal(setWith(Object, childDotPath, exampleData, {}))
+    })
+  })
+
+  describe('MERGE action', () => {
+    it.skip('deletes data from state when data is null', () => {
+      action = { type: actionTypes.MERGE, path: 'test' }
+      expect(firebaseStateReducer({}, action))
+        .to.deep.equal(initialState)
+    })
+
+    it('merge data to empty state under path', () => {
+      action = { type: actionTypes.MERGE, path, data: exampleData }
+      expect(firebaseStateReducer({}, action).data)
+        .to.deep.equal({
+          ...initialState.data,
+          [path]: exampleData
+        })
+    })
+
+    it('merge data to empty state under paths that end in a number', () => {
+      action = { type: actionTypes.MERGE, path: 'test/123', data: exampleData }
+      expect(firebaseStateReducer({}, action).data)
+        .to.deep.equal({
+          ...initialState.data,
+          test: {
+            123: exampleData
+          }
+        })
+    })
+
+    it('merges data to path with already existing data', () => {
+      initialData = { data: { test: { [childKey]: { foo1: 'bar1' } } } }
+      action = { type: actionTypes.MERGE, path: childPath, data: { foo2: 'bar2' } }
+      expect(firebaseStateReducer(initialData, action).data)
+        .to.deep.equal({
+          ...initialState.data,
+          test: {
+            [childKey]: {
+              foo1: 'bar1',
+              foo2: 'bar2'
+            }
+          }
+        })
+    })
+
+    it('merges data to path with already existing data with numeric keys', () => {
+      initialData = { data: { test: { [childKey]: { 123: 'bar1' } } } }
+      action = { type: actionTypes.MERGE, path: childPath, data: { 124: 'bar2' } }
+      expect(firebaseStateReducer(initialData, action).data)
+        .to.deep.equal({
+          ...initialState.data,
+          test: {
+            [childKey]: {
+              123: 'bar1',
+              124: 'bar2'
+            }
+          }
+        })
+    })
+
+    it('merge data to path with already existing value of null', () => {
+      initialData = { data: { test: { [childKey]: null } } }
+      action = { type: actionTypes.MERGE, path: childPath, data: newData }
+      expect(firebaseStateReducer(initialData, action).data)
+        .to.deep.equal(setWith(Object, childDotPath, newData, {}))
+    })
+
+    it('merge data to path with already existing parent of null', () => {
+      initialData = { data: { test: null } }
+      action = { type: actionTypes.MERGE, path: childPath, data: exampleData }
       expect(firebaseStateReducer(initialData, action).data)
         .to.deep.equal(setWith(Object, childDotPath, exampleData, {}))
     })

--- a/tests/unit/reducer.spec.js
+++ b/tests/unit/reducer.spec.js
@@ -145,6 +145,36 @@ describe('reducer', () => {
         })
     })
 
+    it('sets data to path with already existing data', () => {
+      initialData = { data: { test: { [childKey]: { foo1: 'bar1' } } } }
+      action = { type: actionTypes.SET, path: childPath, data: { foo2: 'bar2' } }
+      expect(firebaseStateReducer(initialData, action).data)
+        .to.deep.equal({
+          ...initialState.data,
+          test: {
+            [childKey]: {
+              foo1: 'bar1',
+              foo2: 'bar2'
+            }
+          }
+        })
+    })
+
+    it('sets data to path with already existing data with numeric keys', () => {
+      initialData = { data: { test: { [childKey]: { 123: 'bar1' } } } }
+      action = { type: actionTypes.SET, path: childPath, data: { 124: 'bar2' } }
+      expect(firebaseStateReducer(initialData, action).data)
+        .to.deep.equal({
+          ...initialState.data,
+          test: {
+            [childKey]: {
+              123: 'bar1',
+              124: 'bar2'
+            }
+          }
+        })
+    })
+
     it('sets data to path with already existing value of null', () => {
       initialData = { data: { test: { [childKey]: null } } }
       action = { type: actionTypes.SET, path: childPath, data: newData }


### PR DESCRIPTION
### Description

I previously made the v2.0.0 SET action merge redux state data rather than overwrite it. This fixed a bug with multiple queries using population (and likely also issue #130), but it had unintended consequences for regular data subscriptions (most notably: if a field is deleted from a single object being subscribed to, it won't get deleted by the reducer).

This PR reverts that change and introduces a new MERGE action that keeps this merge semantics when useful. For now, I use MERGE when populating data only to fix the aforementioned bug. Down the road, it can be exposed to end-users as an option in a query. This may be useful, for example, when subscribing to collections of objects that one might not want to overwrite across different containers.

### Check List
If not relevant to pull request, check off as complete

- [X] All tests passing
- [X] Docs updated with any changes or examples if applicable
- [X] Added tests to ensure new feature(s) work properly


