### PR TITLE
fix(populate) Fixed populate function to return null for null paths.

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -15,7 +15,7 @@
       "comments": false
     },
     "test": {
-      "plugins": ["transform-decorators-legacy", "transform-async-to-generator"]
+      "plugins": ["transform-runtime", "transform-decorators-legacy", "transform-async-to-generator"]
     }
   }
 }

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -178,11 +178,17 @@ export const populate = (state, path, populates, notSetValue) => {
     : splitPath
   const dotPath = pathArr.join('.')
   // Gather data from top level if path is profile (handles populating profile)
-  const data = get(state, dotPath)
-  // return notSetValue of undefined child
-  if (!state || !data) {
+  const data = get(state, dotPath, notSetValue)
+
+  // Return notSetValue for undefined child
+  if (!state || data === notSetValue) {
     return notSetValue
   }
+  // Return null for null child
+  if (data === null) {
+    return null
+  }
+
   // check for if data is single object or a list of objects
   const populatesForData = getPopulateObjs(
     isFunction(populates)

--- a/tests/unit/helpers.spec.js
+++ b/tests/unit/helpers.spec.js
@@ -50,6 +50,9 @@ const exampleData = {
       123: {
         text: 'Some Text'
       }
+    },
+    missing: {
+      data: null
     }
   },
   ordered: {
@@ -112,6 +115,12 @@ describe('Helpers:', () => {
       expect(helpers.populate(exampleData, '/asdfasdfadsf', []))
         .to
         .equal(undefined)
+    })
+
+    it('returns null for null data', () => {
+      expect(helpers.populate(exampleData, '/missing/data', []))
+        .to
+        .equal(null)
     })
 
     it('returns unpopulated data for no populates', () => {


### PR DESCRIPTION
### Description
Fixed populate function to return null for null paths.

Also made a small change to babelrc file to make tests run in my environment.

### Check List
If not relevant to pull request, check off as complete

- [X] All tests passing
- [X] Docs updated with any changes or examples if applicable
- [X] Added tests to ensure new feature(s) work properly


