### PR TITLE
fix(docs): typo in redux-saga recipe doc

### DIFF
--- a/docs/recipes/redux-saga.md
+++ b/docs/recipes/redux-saga.md
@@ -1,4 +1,4 @@
-# Redux Form Recipes
+# Redux Saga Recipes
 
 In order to use `react-redux-firebase` instance within sagas, pass it as the second argument of the run function `sagaMiddleware.run(helloSaga, getFirebase)`.
 


### PR DESCRIPTION
### Description
Correct title in redux saga docs from "Redux Form Recipes" -> "Redux Saga Recipes"

### Check List
If not relevant to pull request, check off as complete

- [x] All tests passing
- [x] Docs updated with any changes or examples if applicable
- [x] Added tests to ensure new feature(s) work properly

### Relevant Issues
* #276 
