### PR TITLE
Fix error in redux-auth-wrapper example

### DIFF
--- a/docs/recipes/routing.md
+++ b/docs/recipes/routing.md
@@ -97,7 +97,7 @@ export const UserIsNotAuthenticated = connectedRouterRedirect({
   redirectPath: (state, ownProps) => locationHelper.getRedirectQueryParam(ownProps) || '/dashboard',
   allowRedirectBack: false,
   authenticatedSelector: ({ firebase: { auth } }) =>
-    auth && auth.isLoaded && !auth.isEmpty,
+    auth && auth.isLoaded && auth.isEmpty,
   authenticatingSelector: ({ firebase: { auth } }) =>
     auth === undefined || !auth.isLoaded,
   wrapperDisplayName: 'UserIsNotAuthenticated',


### PR DESCRIPTION
The `authenticatedSelector` for `UserIsNotAuthenticated` was wrong. Currently both conditions are the same, which leads to an infinite redirect.

### Description


### Check List
If not relevant to pull request, check off as complete

- [ ] All tests passing
- [x] Docs updated with any changes or examples if applicable
- [x] Added tests to ensure new feature(s) work properly

### Relevant Issues
<!-- * #1 -->
