### PR TITLE
fix(populate): multiple populates when missing child key

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -132,7 +132,7 @@ const populateChild = (state, child, p) => {
   // no matching child parameter
   const childVal = get(child, p.child)
   if (!child || !childVal) {
-    return child
+    return null
   }
   // populate child is key
   if (isString(childVal)) {

--- a/tests/unit/helpers.spec.js
+++ b/tests/unit/helpers.spec.js
@@ -6,6 +6,7 @@ const exampleData = {
     projects: {
       CDF: {
         owner: 'ABC',
+        category: 'cat1',
         notes: {
           123: true
         },
@@ -15,7 +16,8 @@ const exampleData = {
         }
       },
       GHI: {
-        owner: 'ABC'
+        owner: 'ABC',
+        category: 'cat2'
       },
       OKF: {
         owner: 'asdfasdf',
@@ -29,9 +31,20 @@ const exampleData = {
       },
       QRS: {
         owner: 'ABC',
+        category: 'cat1',
         nested: {
           owner: 'ABC'
         },
+        notes: {
+          123: true
+        },
+        collaborators: {
+          ABC: true,
+          abc: true
+        }
+      },
+      TUV: {
+        owner: 'ABC',
         notes: {
           123: true
         },
@@ -44,6 +57,14 @@ const exampleData = {
     users: {
       ABC: {
         displayName: 'scott'
+      }
+    },
+    categories: {
+      cat1: {
+        displayName: 'magic'
+      },
+      cat2: {
+        displayName: 'animals'
       }
     },
     notes: {
@@ -209,6 +230,21 @@ describe('Helpers:', () => {
           const rootName = 'users'
           const valName = 'CDF'
           expect(helpers.populate(exampleData, path, [{ child: 'owner', root: rootName }])[valName].owner)
+            .to
+            .have
+            .property('displayName', 'scott')
+        })
+
+        it('populates value even when others are missing', () => {
+          const path = 'projects'
+          const rootName = 'users'
+          const catRootName = 'categories'
+          const valName = 'TUV'
+          const populates = [
+            { child: 'owner', root: rootName },
+            { child: 'category', root: catRootName }
+          ]
+          expect(helpers.populate(exampleData, path, populates)[valName].owner)
             .to
             .have
             .property('displayName', 'scott')


### PR DESCRIPTION
### Description

This is a minor update to `populateChild` function in `helpers.js` to returns `null` instead of `child`. This works because the returned value is used in `reduce` function that combines values. 

Previously, already written populates values could be overwritten when `child` was returned.
A new failing test was written to reproduce the issue and is now passing. I've also confirmed this fix in a private repo with `npm link`.

### Check List
If not relevant to pull request, check off as complete

- [x] All tests passing
- [x] Docs updated with any changes or examples if applicable
- [x] Added tests to ensure new feature(s) work properly

### Relevant Issues

Fixes #277.
