### PR TITLE
feat(core): non-HOC version of firebaseConnect, for use with server side rendering

### DIFF
--- a/src/createFirebaseInstance.js
+++ b/src/createFirebaseInstance.js
@@ -1,5 +1,6 @@
 import { isObject } from 'lodash'
 import { authActions, queryActions, storageActions } from './actions'
+import { getEventsFromInput, createCallable } from './utils'
 
 /**
  * Create a firebase instance that has helpers attached for dispatching actions
@@ -240,6 +241,27 @@ export const createFirebaseInstance = (firebase, configs, dispatch) => {
     storageActions.deleteFile(dispatch, firebase, { path, dbPath })
 
   /**
+   * @description Connect. Similar to the firebaseConnect Higher Order
+   * Component but presented as a function. Useful for populating your redux
+   * state without React, e.g., for service side rendering.
+   * @param {Array} watchArray - Array of objects or strings for paths to sync
+   * from Firebase. Can also be a function that returns the array. The function
+   * is passed the props object specified as the next parameter.
+   * @param {Object} props - The props object that you would like to pass to
+   * your watchArray generating function.
+   * @return {Promise}
+   */
+  const connect = (watchArray, props) => {
+    const inputAsFunc = createCallable(watchArray)
+    const prevData = inputAsFunc(props, firebase)
+    const firebaseEvents = getEventsFromInput(prevData)
+    const promises = firebaseEvents.map(event =>
+      queryActions.watchEvent(firebase, dispatch, event))
+
+    return Promise.all(promises)
+  }
+
+  /**
    * @description Watch event. **Note:** this method is used internally
    * so examples have not yet been created, and it may not work as expected.
    * @param {String} type - Type of watch event
@@ -407,7 +429,8 @@ export const createFirebaseInstance = (firebase, configs, dispatch) => {
     watchEvent,
     unWatchEvent,
     reloadAuth,
-    linkWithCredential
+    linkWithCredential,
+    connect
   }
 
   return Object.assign(firebase, helpers, { helpers })

--- a/src/createFirebaseInstance.js
+++ b/src/createFirebaseInstance.js
@@ -241,7 +241,7 @@ export const createFirebaseInstance = (firebase, configs, dispatch) => {
     storageActions.deleteFile(dispatch, firebase, { path, dbPath })
 
   /**
-   * @description Connect. Similar to the firebaseConnect Higher Order
+   * @description firebaseWatch. Similar to the firebaseConnect Higher Order
    * Component but presented as a function. Useful for populating your redux
    * state without React, e.g., for service side rendering.
    * @param {Array} watchArray - Array of objects or strings for paths to sync
@@ -251,7 +251,7 @@ export const createFirebaseInstance = (firebase, configs, dispatch) => {
    * your watchArray generating function.
    * @return {Promise}
    */
-  const connect = (watchArray, props) => {
+  const firebaseWatch = (watchArray, props) => {
     const inputAsFunc = createCallable(watchArray)
     const prevData = inputAsFunc(props, firebase)
     const firebaseEvents = getEventsFromInput(prevData)
@@ -430,7 +430,7 @@ export const createFirebaseInstance = (firebase, configs, dispatch) => {
     unWatchEvent,
     reloadAuth,
     linkWithCredential,
-    connect
+    firebaseWatch
   }
 
   return Object.assign(firebase, helpers, { helpers })

--- a/tests/unit/enhancer.spec.js
+++ b/tests/unit/enhancer.spec.js
@@ -145,9 +145,9 @@ describe('Compose', () => {
       })
     })
 
-    describe('connect', () => {
-      it('starts connect', async () => {
-        await store.firebase.connect(['test'])
+    describe('firebaseWatch', () => {
+      it('starts firebaseWatch', async () => {
+        await store.firebase.firebaseWatch(['test'])
         expect(store.firebase.ref('test')).to.be.an.object
       })
     })

--- a/tests/unit/enhancer.spec.js
+++ b/tests/unit/enhancer.spec.js
@@ -145,10 +145,17 @@ describe('Compose', () => {
       })
     })
 
+    describe('connect', () => {
+      it('starts connect', async () => {
+        await store.firebase.connect(['test'])
+        expect(store.firebase.ref('test')).to.be.an.object
+      })
+    })
+
     describe('watchEvent', () => {
-      it('starts watcher', () => {
-        // TODO: Confirm that watcher count is updated and watcher is set
-        store.firebase.watchEvent('value', 'test')
+      it('starts watcher', async () => {
+        await store.firebase.watchEvent('value', 'test')
+        expect(store.firebase.ref('test')).to.be.an.object
       })
     })
 


### PR DESCRIPTION
### Description

This PR adds a new `connect` helper to the props.firebase object that lets users connect their redux store to the firebase DB without requiring the firebaseConnect HOC. This is useful for populating your redux state ahead of rendering your React app, a typical pattern when performing server side rendering.

### Check List
If not relevant to pull request, check off as complete

- [X] All tests passing
- [X] Docs updated with any changes or examples if applicable
- [X] Added tests to ensure new feature(s) work properly
