### PR TITLE
Remove an artifact from a previous merge conflict

### DIFF
--- a/docs/api/props-firebase.md
+++ b/docs/api/props-firebase.md
@@ -322,4 +322,3 @@ Returns [**Storage**](https://firebase.google.com/docs/reference/js/firebase.sto
 Firebase messaging service instance including all Firebase messaging methods
 
 Returns **firebase.messaging** Firebase messaging service
->>>>>>> master

--- a/docs/integrations/react-native.md
+++ b/docs/integrations/react-native.md
@@ -266,8 +266,6 @@ AppRegistry.registerComponent('GoogleSigninSampleApp', () => GoogleSigninSampleA
 
 ```
 
->>>>>>> master
-
 ## Creating Your Own
 
 We are going to use the project name Devshare for example here. For your project, use your project name everywhere where Devshare is used.

--- a/index.d.ts
+++ b/index.d.ts
@@ -134,7 +134,6 @@ export function reactReduxFirebase(fbConfig: ConfigObject, otherConfig: any, ...
 export function reduxFirebase(fbConfig: ConfigObject, otherConfig: any, ...args: any[]): any;
 
 export function reduxReactFirebase(fbConfig: ConfigObject, otherConfig: any, ...args: any[]): any;
->>>>>>> master
 
 export function toJS(data: any): any;
 


### PR DESCRIPTION
### Description

This is a fix to this error we currently get when using typescript on the beta.12 branch:
```Build failed!

✖ ERROR [at-loader] ./node_modules/react-redux-firebase/index.d.ts:137:1
    TS1185: Merge conflict marker encountered.
```

From what i understand, this came from a merge conflict so i went ahead and patched it :)

### Check List
If not relevant to pull request, check off as complete

- [x] All tests passing
- [x] Docs updated with any changes or examples if applicable
- [x] Added tests to ensure new feature(s) work properly

Also, while i'm at it, thanks for the great lib ️:heart:
