### PR TITLE
Add EMPTY_AUTH_CHANGE case to Profile Reducer

### DIFF
--- a/src/actions/auth.js
+++ b/src/actions/auth.js
@@ -303,7 +303,6 @@ const handleAuthStateChange = (dispatch, firebase, authData) => {
         firebase._.config.onAuthStateChanged(authData, firebase, dispatch)
       }
       dispatch({ type: actionTypes.AUTH_EMPTY_CHANGE })
-      dispatch({ type: actionTypes.SET_PROFILE })
     }
   } else {
     firebase._.authUid = authData.uid // eslint-disable-line no-param-reassign

--- a/src/actions/auth.js
+++ b/src/actions/auth.js
@@ -303,6 +303,7 @@ const handleAuthStateChange = (dispatch, firebase, authData) => {
         firebase._.config.onAuthStateChanged(authData, firebase, dispatch)
       }
       dispatch({ type: actionTypes.AUTH_EMPTY_CHANGE })
+      dispatch({ type: actionTypes.SET_PROFILE })
     }
   } else {
     firebase._.authUid = authData.uid // eslint-disable-line no-param-reassign

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -295,6 +295,7 @@ export const profileReducer = (state = { isLoaded: false, isEmpty: true }, actio
         isLoaded: true
       }
     case LOGOUT:
+    case AUTH_EMPTY_CHANGE:
       // Support keeping data when logging out
       if (action.preserve && action.preserve.profile) {
         return pick(state, action.preserve.profile) // pick returns a new object


### PR DESCRIPTION
### Description
Adds EMPTY_AUTH_CHANGE case to profile reducer, so that firebase.profile is also updated to `{ isLoaded: true, isEmpty: true }` on empty auth changes.

### Check List
If not relevant to pull request, check off as complete

- [ ] All tests passing
- [ ] Docs updated with any changes or examples if applicable
- [ ] Added tests to ensure new feature(s) work properly

### Relevant Issues
<!-- * #1 -->
