### PR TITLE
fix(populate): dispatch for errors during profile population

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-redux-firebase",
-  "version": "2.0.0-beta.13",
+  "version": "2.0.0-beta.15",
   "description": "Redux integration for Firebase. Comes with a Higher Order Components for use with React.",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/src/actions/auth.js
+++ b/src/actions/auth.js
@@ -114,6 +114,12 @@ export const handleProfileWatchResponse = (dispatch, firebase, userProfileSnap) 
         })
       }
     })
+    .catch((err) => {
+      // Error retrieving data for population onto profile.
+      dispatch({ type: actionTypes.UNAUTHORIZED_ERROR, authError: `Error during profile population: ${err.message}` })
+      // Update profile with un-populated version
+      dispatch({ type: actionTypes.SET_PROFILE, profile })
+    })
   }
 }
 


### PR DESCRIPTION
### Description
This PR adds logic to catch errors during profile parameter population.  If a the client does not have access to the data to populate, SET_PROFILE is dispatched with the unpopulated profile.  Previously, an uncaught error prevented the profile from being updated.

### Check List
If not relevant to pull request, check off as complete

- [X ] All tests passing
- [N/A] Docs updated with any changes or examples if applicable
- [N/A] Added tests to ensure new feature(s) work properly

### Relevant Issues
<!-- * #1 -->
