### PR TITLE
Remove deep property for REMOVE action instead of setting it to undefined

### DIFF
--- a/src/reducer.js
+++ b/src/reducer.js
@@ -1,6 +1,6 @@
 import { actionTypes } from './constants'
 import { pick, omit, get, isArray, isObject } from 'lodash'
-import { setWith, assign } from 'lodash/fp'
+import { setWith, assign, unset } from 'lodash/fp'
 
 const {
   START,
@@ -185,7 +185,7 @@ const createDataReducer = (actionKey = 'data') => (state = {}, action) => {
     case NO_VALUE:
       return setWith(Object, getDotStrPath(action.path), null, state)
     case REMOVE:
-      return setWith(Object, getDotStrPath(action.path), undefined, state)
+      return unset(getDotStrPath(action.path), state)
     case LOGOUT:
       // support keeping data when logging out - #125
       if (action.preserve) {

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -51,22 +51,24 @@ export const getDotStrPath = path => pathToArr(path).join('.')
  * Recursively unset a property starting at the deep path, and unsetting the parent
  * property if there are no other enumerable properties at that level.
  * @param  {String} path - Deep dot path of the property to unset
+ * @param {Boolean} [isRecursiveCall=false] - Used internally to ensure that
+ * the object size check is only performed after one iteration.
  * @return {Object} The object with the property deeply unset
  * @private
  */
-export const recursiveUnset = (path, obj) => {
+export const recursiveUnset = (path, obj, isRecursiveCall = false) => {
   if (!path) {
     return obj
   }
 
-  if (size(get(obj, path)) > 0) {
+  if (size(get(obj, path)) > 0 && isRecursiveCall) {
     return obj
   }
   // The object does not have any other properties at this level.  Remove the
   // property.
   const objectWithRemovedKey = unset(path, obj)
   const newPath = path.match(/\./) ? replace(path, /\.[^.]*$/, '') : ''
-  return recursiveUnset(newPath, objectWithRemovedKey)
+  return recursiveUnset(newPath, objectWithRemovedKey, true)
 }
 
 /**


### PR DESCRIPTION
### Description
setWith sets the value to undefined, but the key remains an enumerable
property on the object.  This can cause problems when your UI iterates
over keys of an object and renders based on the key’s existence.  Using
unset, the key is removed.

### Check List
If not relevant to pull request, check off as complete

- [ ] All tests passing
- [ ] Docs updated with any changes or examples if applicable
- [ ] Added tests to ensure new feature(s) work properly

### Relevant Issues
<!-- * #1 -->
