### PR TITLE
Github docs different than 2.0 docs on site

### DIFF
--- a/docs/recipes/roles.md
+++ b/docs/recipes/roles.md
@@ -146,7 +146,7 @@ export const UserIsAdmin = UserAuthWrapper({
 Here is an example of a UserHasPermission HOC that allows us to pass in a string permission (such as todos):
 
 _Tip: you can place the below HOC in `router.js` together with `UserIsNotAuthenticated` and `UserIsAuthenticated`._
-
+//this is different below for version 2.0. please see extended comment, there are a couple of syntax errors nothing major//
 ```js
 import { get } from 'lodash';
 import { UserAuthWrapper } from 'redux-auth-wrapper';


### PR DESCRIPTION
Hello the HOC has a couple of syntax errors on the actual site for version 2.0. I was trying to edit here and update.

### Description


### Check List
If not relevant to pull request, check off as complete

- [ ] All tests passing
- [ ] Docs updated with any changes or examples if applicable
- [ ] Added tests to ensure new feature(s) work properly

### Relevant Issues
<!-- * #1 -->
