### PR TITLE
docs(fix): missing populate in import statement

### DIFF
--- a/docs/populate.md
+++ b/docs/populate.md
@@ -8,7 +8,7 @@ A basic implementation can look like so:
 ```javascript
 import { compose } from 'redux'
 import { connect } from 'react-redux'
-import { firebaseConnect } from 'react-redux-firebase'
+import { firebaseConnect, populate } from 'react-redux-firebase'
 
 const populates = [
   { child: 'owner', root: 'users' } // replace owner with user object


### PR DESCRIPTION
Missing `populate` in import statement.

### Description


### Check List
If not relevant to pull request, check off as complete

- [x] All tests passing
- [x] Docs updated with any changes or examples if applicable
- [x] Added tests to ensure new feature(s) work properly

### Relevant Issues
<!-- * #1 -->
