### PR TITLE
Remove extra Firestore section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,14 +306,6 @@ If you plan to use Firestore, you should checkout [`redux-firestore`][redux-fire
 
 Currently `react-redux-firebase` still handles auth when using [`redux-firestore`][redux-firestore] - The future plan is to also have auth standalone auth library that will allow the developer to choose which pieces they do/do not want.
 
-## Firestore
-
-If you plan to use Firestore, you should checkout [`redux-firestore`][redux-firestore]. It integrates nicely with `react-redux-firebase` (v2 only) and it allows you to run Real Time Database and Firestore along side each other.
-
-`react-redux-firebase` provides the `firestoreConnect` HOC (similar to `firebaseConnect`) for easy setting/unsetting of listeners.
-
-Currently `react-redux-firebase` still handles auth when using [`redux-firestore`][redux-firestore] - The future plan is to also have auth standalone auth library that will allow the developer to choose which pieces they do/do not want.
-
 ## Starting A Project
 
 ### Generator


### PR DESCRIPTION
### Description
I noticed there was a duplicate section regarding Firestore in the README.

### Check List
If not relevant to pull request, check off as complete

- [x] All tests passing
- [x] Docs updated with any changes or examples if applicable
- [x] Added tests to ensure new feature(s) work properly

### Relevant Issues
<!-- * #1 -->
