### PR TITLE
fix(docs): remove typo from redux-thunk integration docs

### DIFF
--- a/docs/integrations/thunks.md
+++ b/docs/integrations/thunks.md
@@ -16,9 +16,9 @@ const store = createStore(
   makeRootReducer(),
   initialState,
   compose(
-    applyMiddleware([
+    applyMiddleware(
       thunk.withExtraArgument(getFirebase) // Pass getFirebase function as extra argument
-    ]),
+    ),
     reactReduxFirebase(fbConfig, { userProfile: 'users', enableLogging: false })
   )
 );


### PR DESCRIPTION
otherwise it will throw `middleware is not a function` error

for version:
```
    "react-redux": "^5.0.6",
    "react-redux-firebase": "^2.0.3",
    "redux": "^3.7.2",
    "redux-thunk": "^2.2.0"
```

### Description


### Check List
If not relevant to pull request, check off as complete

- [x] All tests passing
- [x] Docs updated with any changes or examples if applicable
- [x] Added tests to ensure new feature(s) work properly

### Relevant Issues
<!-- * #1 -->
