### PR TITLE
fix(docs): remove old reference to orderedToJS

### DIFF
--- a/docs/queries.md
+++ b/docs/queries.md
@@ -101,7 +101,7 @@ compose(
 
 ##### ordered {#ordered}
 
-In order to get ordered data, use `orderedToJS`
+In order to get ordered data, use `ordered`
 
 ###### Examples
 1. Get list of projects ordered by key


### PR DESCRIPTION
### Description
`orderedToJS` is no longer available in 2.0. It was mentioned in the docs. The example was already updated though.

### Check List
If not relevant to pull request, check off as complete

- [x] All tests passing
- [x] Docs updated with any changes or examples if applicable
- [x] Added tests to ensure new feature(s) work properly
