### PR TITLE
v2.0.4

### DIFF
--- a/docs/api/firebaseInstance.md
+++ b/docs/api/firebaseInstance.md
@@ -397,10 +397,11 @@ internally while updating profile on Firestore uses `set` with
 -   `profileUpdate` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** Profile data to place in new profile
 -   `options` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** Options object (used to change how profile
     update occurs)
-    -   `options.useUpdate` **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Use update instead of set with merge
-        (only used when updating profile on Firestore)
-    -   `options.merge` **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Whether or not to use merge when setting
-        (only used when updating profile on Firestore)
+    -   `options.useSet` **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Use set with merge instead of
+        update. Setting to `false` uses update (can cause issue of profile document
+        does not exist). Note: Only used when updating profile on Firestore (optional, default `true`)
+    -   `options.merge` **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Whether or not to use merge when
+        setting profile. Note: Only used when updating profile on Firestore (optional, default `true`)
 
 Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)** 
 

--- a/docs/api/firebaseInstance.md
+++ b/docs/api/firebaseInstance.md
@@ -387,12 +387,20 @@ Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/
 
 ## updateProfile
 
-Update user profile
+Update user profile on Firebase Real Time Database or
+Firestore (if `useFirestoreForProfile: true` config passed to
+reactReduxFirebase). Real Time Database update uses `update` method
+internally while updating profile on Firestore uses `set` with
 
 **Parameters**
 
--   `profileUpdate`  
--   `profile` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** Profile data to place in new profile
+-   `profileUpdate` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** Profile data to place in new profile
+-   `options` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** Options object (used to change how profile
+    update occurs)
+    -   `options.useUpdate` **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Use update instead of set with merge
+        (only used when updating profile on Firestore)
+    -   `options.merge` **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Whether or not to use merge when setting
+        (only used when updating profile on Firestore)
 
 Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)** 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-redux-firebase",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-redux-firebase",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Redux integration for Firebase. Comes with a Higher Order Components for use with React.",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/src/actions/auth.js
+++ b/src/actions/auth.js
@@ -345,13 +345,13 @@ const handleAuthStateChange = (dispatch, firebase, authData) => {
       setupPresence(dispatch, firebase)
     }
 
-    watchUserProfile(dispatch, firebase)
-
     dispatch({
       type: actionTypes.LOGIN,
       auth: authData,
       preserve: config.preserveOnLogin
     })
+
+    watchUserProfile(dispatch, firebase)
 
     // Run onAuthStateChanged if it exists in config
     if (isFunction(config.onAuthStateChanged)) {

--- a/src/actions/auth.js
+++ b/src/actions/auth.js
@@ -29,7 +29,7 @@ const dispatchLoginError = (dispatch, authError) =>
 export const unWatchUserProfile = firebase => {
   const {
     authUid,
-    config: {userProfile, useFirestoreForProfile}
+    config: { userProfile, useFirestoreForProfile }
   } = firebase._
   if (firebase._.profileWatch) {
     if (useFirestoreForProfile && firebase.firestore) {
@@ -212,8 +212,12 @@ export const createUserProfile = (dispatch, firebase, userData, profile) => {
       .doc(userData.uid)
       .get()
       .then(profileSnap => {
-        let newProfile = {}
+        // Return if config for updating profile is not enabled and profile exists
+        if (!config.updateProfileOnLogin && profileSnap.exists) {
+          return profileSnap.data()
+        }
 
+        let newProfile = {}
         // If the user did supply a profileFactory, we should use the result of it for the new Profile
         if (isFunction(config.profileFactory)) {
           newProfile = profile
@@ -229,10 +233,6 @@ export const createUserProfile = (dispatch, firebase, userData, profile) => {
           }
         }
 
-        // Return if config for updating profile is not enabled and profile exists
-        if (!config.updateProfileOnLogin && profileSnap.exists) {
-          return profileSnap.data()
-        }
         // Create/Update the profile
         return profileSnap.ref
           .set(newProfile, { merge: true })

--- a/src/actions/auth.js
+++ b/src/actions/auth.js
@@ -1,7 +1,6 @@
 import { isArray, isString, isFunction, forEach, omit } from 'lodash'
 import { actionTypes } from '../constants'
 import { populate } from '../helpers'
-import { stringToDate } from '../utils'
 import {
   getLoginMethodAndParams,
   updateProfileOnRTDB,
@@ -227,9 +226,7 @@ export const createUserProfile = (dispatch, firebase, userData, profile) => {
           // Remove unnecessary auth params (configurable) and preserve types of timestamps
           newProfile = {
             ...omit(userDataObject, config.keysToRemoveFromAuth),
-            avatarUrl: userDataObject.photoURL, // match profile pattern used for RTDB
-            createdAt: stringToDate(userDataObject.metadata.creationTime),
-            lastLoginAt: stringToDate(userDataObject.metadata.lastSignInTime)
+            avatarUrl: userDataObject.photoURL // match profile pattern used for RTDB
           }
         }
 

--- a/src/createFirebaseInstance.js
+++ b/src/createFirebaseInstance.js
@@ -408,12 +408,21 @@ export const createFirebaseInstance = (firebase, configs, dispatch) => {
     authActions.verifyPasswordResetCode(dispatch, firebase, code)
 
   /**
-   * @description Update user profile
-   * @param {Object} profile - Profile data to place in new profile
+   * @description Update user profile on Firebase Real Time Database or
+   * Firestore (if `useFirestoreForProfile: true` config passed to
+   * reactReduxFirebase). Real Time Database update uses `update` method
+   * internally while updating profile on Firestore uses `set` with
+   * @param {Object} profileUpdate - Profile data to place in new profile
+   * @param {Object} options - Options object (used to change how profile
+   * update occurs)
+   * @param  {Boolean} options.useUpdate - Use update instead of set with merge
+   * (only used when updating profile on Firestore)
+   * @param  {Boolean} options.merge - Whether or not to use merge when setting
+   * (only used when updating profile on Firestore)
    * @return {Promise}
    */
-  const updateProfile = profileUpdate =>
-    authActions.updateProfile(dispatch, firebase, profileUpdate)
+  const updateProfile = (profileUpdate, options) =>
+    authActions.updateProfile(dispatch, firebase, profileUpdate, options)
 
   /**
    * @description Update Auth Object

--- a/src/createFirebaseInstance.js
+++ b/src/createFirebaseInstance.js
@@ -415,10 +415,11 @@ export const createFirebaseInstance = (firebase, configs, dispatch) => {
    * @param {Object} profileUpdate - Profile data to place in new profile
    * @param {Object} options - Options object (used to change how profile
    * update occurs)
-   * @param  {Boolean} options.useUpdate - Use update instead of set with merge
-   * (only used when updating profile on Firestore)
-   * @param  {Boolean} options.merge - Whether or not to use merge when setting
-   * (only used when updating profile on Firestore)
+   * @param  {Boolean} [options.useSet=true] - Use set with merge instead of
+   * update. Setting to `false` uses update (can cause issue of profile document
+   * does not exist). Note: Only used when updating profile on Firestore
+   * @param  {Boolean} [options.merge=true] - Whether or not to use merge when
+   * setting profile. Note: Only used when updating profile on Firestore
    * @return {Promise}
    */
   const updateProfile = (profileUpdate, options) =>

--- a/src/reducers.js
+++ b/src/reducers.js
@@ -28,7 +28,8 @@ const {
   AUTH_LINK_SUCCESS,
   UNAUTHORIZED_ERROR,
   AUTH_UPDATE_SUCCESS,
-  AUTH_RELOAD_SUCCESS
+  AUTH_RELOAD_SUCCESS,
+  PROFILE_UPDATE_SUCCESS
 } = actionTypes
 
 /**
@@ -281,6 +282,8 @@ export const profileReducer = (
         isEmpty: false,
         isLoaded: true
       }
+    case PROFILE_UPDATE_SUCCESS:
+      return Object.assign({}, state, action.payload)
     case LOGIN:
       // Support keeping data when logging out
       if (action.preserve && action.preserve.profile) {

--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -197,9 +197,11 @@ export const updateProfileOnRTDB = (firebase, profileUpdate) => {
  * @param  {Object} profileUpdate - Updates to profile object
  * @param  {Object} options - Options object for configuring how profile
  * update occurs
- * @param  {Boolean} options.useUpdate - Use update instead of set with merge
- * @param  {Boolean} options.merge - Whether or not to use merge when setting
- * profile
+ * @param  {Boolean} [options.useSet=true] - Use set with merge instead of
+ * update. Setting to `false` uses update (can cause issue of profile document
+ * does not exist).
+ * @param  {Boolean} [options.merge=true] - Whether or not to use merge when
+ * setting profile
  * @return {Promise} Resolves with results of profile get
  */
 export const updateProfileOnFirestore = (
@@ -207,10 +209,12 @@ export const updateProfileOnFirestore = (
   profileUpdate,
   options = {}
 ) => {
-  const { useUpdate = false, merge = true } = options
+  const { useSet = true, merge = true } = options
   const { firestore, _: { config, authUid } } = firebase
   const profileRef = firestore().doc(`${config.userProfile}/${authUid}`)
-  const profileUpdatePromise = useUpdate
+  // Use set with merge (to prevent "No document to update") unless otherwise
+  // specificed through options
+  const profileUpdatePromise = useSet
     ? profileRef.set(profileUpdate, { merge })
     : profileRef.update(profileUpdate)
   return profileUpdatePromise.then(() => profileRef.get())

--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -191,13 +191,27 @@ export const updateProfileOnRTDB = (firebase, profileUpdate) => {
 }
 
 /**
- * Update profile data on Firestore
+ * Update profile data on Firestore by calling set (with merge: true) on
+ * the profile.
  * @param  {Object} firebase - internal firebase object
  * @param  {Object} profileUpdate - Updates to profile object
+ * @param  {Object} options - Options object for configuring how profile
+ * update occurs
+ * @param  {Boolean} options.useUpdate - Use update instead of set with merge
+ * @param  {Boolean} options.merge - Whether or not to use merge when setting
+ * profile
  * @return {Promise} Resolves with results of profile get
  */
-export const updateProfileOnFirestore = (firebase, profileUpdate) => {
+export const updateProfileOnFirestore = (
+  firebase,
+  profileUpdate,
+  options = {}
+) => {
+  const { useUpdate = false, merge = true } = options
   const { firestore, _: { config, authUid } } = firebase
   const profileRef = firestore().doc(`${config.userProfile}/${authUid}`)
-  return profileRef.update(profileUpdate).then(() => profileRef.get())
+  const profileUpdatePromise = useUpdate
+    ? profileRef.set(profileUpdate, { merge })
+    : profileRef.update(profileUpdate)
+  return profileUpdatePromise.then(() => profileRef.get())
 }

--- a/test/unit/helpers.spec.js
+++ b/test/unit/helpers.spec.js
@@ -269,6 +269,27 @@ describe('Helpers:', () => {
             exampleData.data[rootName].ABC.displayName
           )
         })
+
+        it('supports childParam', () => {
+          populates = [
+            {
+              child: 'collaborators',
+              root: rootName,
+              childParam: 'displayName'
+            }
+          ]
+          // Non matching collaborator
+          expect(
+            helpers.populate(exampleData, path, populates)
+          ).to.have.deep.property(`${valName}.collaborators.abc`, true)
+          // Matching collaborator
+          expect(
+            helpers.populate(exampleData, path, populates)
+          ).to.have.deep.property(
+            `${valName}.collaborators.ABC`,
+            exampleData.data[rootName].ABC.displayName
+          )
+        })
       })
 
       describe('config as function', () => {
@@ -354,7 +375,6 @@ describe('Helpers:', () => {
         )
       })
 
-      // Skipped since this is not currently supported
       it('from same root', () => {
         populates = [
           { child: 'owner', root: rootName },
@@ -406,6 +426,21 @@ describe('Helpers:', () => {
 
     it('returns true when is loaded', () => {
       expect(helpers.isEmpty([{}])).to.be.false
+    })
+  })
+
+  describe('fixPath', () => {
+    it('exists', () => {
+      expect(helpers).to.respondTo('fixPath')
+    })
+
+    it('returns original path if no fix is required', () => {
+      const originalPath = '/asdf'
+      expect(helpers.fixPath(originalPath)).to.equal(originalPath)
+    })
+
+    it('adds / to beginning of path', () => {
+      expect(helpers.fixPath('asdf')).to.equal('/asdf')
     })
   })
 })

--- a/test/unit/reducer.spec.js
+++ b/test/unit/reducer.spec.js
@@ -527,6 +527,15 @@ describe('reducer', () => {
     })
   })
 
+  describe('PROFILE_UPDATE_SUCCESS action -', () => {
+    it('sets auth state to isLoaded: true, isEmpty: false', () => {
+      const payload = { some: 'value' }
+      action = { type: actionTypes.PROFILE_UPDATE_SUCCESS, payload }
+      const currentState = firebaseReducer({}, action)
+      expect(currentState).to.have.deep.property('profile.some', payload.some)
+    })
+  })
+
   describe('LOGIN action -', () => {
     it('sets auth state to isLoaded: true, isEmpty: false', () => {
       const auth = { some: 'value' }
@@ -551,6 +560,103 @@ describe('reducer', () => {
         'auth.isEmpty',
         true
       )
+    })
+
+    describe('preserve parameter', () => {
+      describe('profile state is preserved when provided', () => {
+        it('an array of keys', () => {
+          const payload = { some: 'other' }
+          const initialState = { profile: { some: 'value' } }
+          action = {
+            type: actionTypes.LOGIN,
+            preserve: { profile: ['some'] },
+            payload
+          }
+          expect(firebaseReducer(initialState, action)).to.have.deep.property(
+            'profile.some',
+            'value'
+          )
+        })
+
+        it('a boolean (true)', () => {
+          const payload = { some: 'other' }
+          const initialState = { profile: { some: 'value' } }
+          action = {
+            type: actionTypes.LOGIN,
+            preserve: { profile: true },
+            payload
+          }
+          expect(firebaseReducer(initialState, action)).to.have.deep.property(
+            'profile.some',
+            'value'
+          )
+        })
+      })
+
+      describe('profile state is updated when is already exists and is provided', () => {
+        it('a boolean (true)', () => {
+          const payload = { some: 'other' }
+          const initialState = { profile: { some: 'value' } }
+          action = {
+            type: actionTypes.LOGIN,
+            preserve: { profile: true },
+            payload
+          }
+          expect(firebaseReducer(initialState, action)).to.have.deep.property(
+            'profile.some',
+            'value'
+          )
+        })
+      })
+
+      describe('auth state is preserved when provided', () => {
+        it('an array of keys', () => {
+          const payload = { some: 'other' }
+          const initialState = { auth: { some: 'value' } }
+          action = {
+            type: actionTypes.LOGIN,
+            preserve: { auth: ['some'] },
+            auth: payload
+          }
+          expect(firebaseReducer(initialState, action)).to.have.deep.property(
+            'auth.some',
+            'value'
+          )
+        })
+
+        it('a boolean (true)', () => {
+          const initialState = { auth: { some: 'value' } }
+          action = {
+            type: actionTypes.LOGIN,
+            preserve: { auth: true },
+            auth: {}
+          }
+          expect(firebaseReducer(initialState, action)).to.have.deep.property(
+            'auth.some',
+            'value'
+          )
+        })
+      })
+
+      describe('auth state is updated when is already exists and is provided', () => {
+        it('a boolean (true)', () => {
+          const payload = { some: 'other', another: 'thing' }
+          const initialState = { auth: { some: 'value' } }
+          action = {
+            type: actionTypes.LOGIN,
+            preserve: { auth: true },
+            auth: payload
+          }
+          expect(firebaseReducer(initialState, action)).to.have.deep.property(
+            'auth.some',
+            payload.some
+          )
+          expect(firebaseReducer(initialState, action)).to.have.deep.property(
+            'auth.another',
+            payload.another
+          )
+        })
+      })
     })
   })
 


### PR DESCRIPTION
### Description
* feat(profileReducer): `PROFILE_UPDATE_SUCCESS` action updates profile state - #395 -
 @serhiipalash
* fix(firestore): prevent issue where default profile creation would break (`createdAt` was undefined) - #391 - @compojoom
* feat(profile): `profileFactory` support for firestore - #391 - @compojoom
* fix(login): login-logout-login flow always correctly updates `state.firebase.profile` - #401 - @evgeni-tsn
* fix(updateProfile): "no document to update" error no longer thrown when updating non-existant profile on Firestore (`useSet` boolean added to make this optional) - #403

### Check List
If not relevant to pull request, check off as complete

- [X] All tests passing
- [X] Docs updated with any changes or examples if applicable
- [X] Added tests to ensure new feature(s) work properly

### Relevant Issues
* #391
* #395
* #401
* #403 
