### PR TITLE
Fix thunk integration example to return object correctly

### DIFF
--- a/docs/integrations/thunks.md
+++ b/docs/integrations/thunks.md
@@ -30,10 +30,11 @@ const store = createStore(
 After following the setup above, `getFirebase` function becomes available within your thunks as the third argument:
 
 ```javascript
-const sendNotification = (payload) => {
+const sendNotification = (payload) => ({
   type: NOTIFICATION,
   payload
-}
+})
+
 export const addTodo = (newTodo) =>
   (dispatch, getState, getFirebase) => {
     const firebase = getFirebase()


### PR DESCRIPTION
### Description

Apologies @prescottprue if these are pedantic, just fixing the docs :)

The example for thunk integrations didn't return the object correctly and would throw an error:

`Actions must be plain objects. Use custom middleware for async actions.`

### Check List
If not relevant to pull request, check off as complete

- [x] All tests passing
- [x] Docs updated with any changes or examples if applicable
- [x] Added tests to ensure new feature(s) work properly

### Relevant Issues
<!-- * #1 -->
