### PR TITLE
fix(storage): fix a typo related to UploadTaskSnapshot within uploadFile

### DIFF
--- a/docs/storage.md
+++ b/docs/storage.md
@@ -34,7 +34,7 @@ Available on `props.firebase` if using `firebaseConnect` HOC or using `getFireba
 -   `options.name` [**String**][string-url] | [**Function**][function-url] - Name of file or function that returns the name of the file. If a function is passed the argument syntax is `(file, internalFirebase, uploadConfig)` where `file` is the file object (`file.name` is used as default if no name option is passed).
 
 ##### Returns
-[**Promise**][promise-url] Resolves with an object containing `uploadTaskSnaphot` which is the [**firebase.storage.UploadTaskSnaphot**][upload-task-snapshot-url] returned from the `storageRef.put` call which happens internally. If `databasePath` is provided `snapshot`, `key`, `File`, and `metaDataSnapshot` parameters are also included.
+[**Promise**][promise-url] Resolves with an object containing `uploadTaskSnapshot` which is the [**firebase.storage.UploadTaskSnapshot**][upload-task-snapshot-url] returned from the `storageRef.put` call which happens internally. If `databasePath` is provided `snapshot`, `key`, `File`, and `metaDataSnapshot` parameters are also included.
 
 #### Examples
 

--- a/src/actions/storage.js
+++ b/src/actions/storage.js
@@ -90,21 +90,27 @@ export const uploadFile = (dispatch, firebase, config) => {
           .put(file)
 
   return uploadPromise()
-    .then(uploadTaskSnaphot => {
+    .then(uploadTaskSnapshot => {
       if (!dbPath || !firebase.database) {
         dispatch({
           type: FILE_UPLOAD_COMPLETE,
           meta: { ...config, filename },
-          payload: { uploadTaskSnaphot }
+          payload: {
+            uploadTaskSnapshot,
+            uploadTaskSnaphot: uploadTaskSnapshot // Preserving legacy typo
+          }
         })
-        return { uploadTaskSnaphot }
+        return {
+          uploadTaskSnapshot,
+          uploadTaskSnaphot: uploadTaskSnapshot // Preserving legacy typo
+        }
       }
-      const { metadata: { name, fullPath, downloadURLs } } = uploadTaskSnaphot
+      const { metadata: { name, fullPath, downloadURLs } } = uploadTaskSnapshot
       const { fileMetadataFactory } = firebase._.config
 
       // Apply fileMetadataFactory if it exists in config
       const fileData = isFunction(fileMetadataFactory)
-        ? fileMetadataFactory(uploadTaskSnaphot, firebase)
+        ? fileMetadataFactory(uploadTaskSnapshot, firebase)
         : {
             name,
             fullPath,
@@ -122,7 +128,8 @@ export const uploadFile = (dispatch, firebase, config) => {
             snapshot: metaDataSnapshot,
             key: metaDataSnapshot.key,
             File: fileData,
-            uploadTaskSnaphot,
+            uploadTaskSnapshot,
+            uploadTaskSnaphot: uploadTaskSnapshot, // Preserving legacy typo
             metaDataSnapshot
           }
           dispatch({


### PR DESCRIPTION
Previously the typo `uploadTaskShaphot` was pervasive throughout the
variables names and return values of firebase storage upload tasks,
including in the objects returned in promise resolutions to the
end-user. This commit preserves the typos in the public interface while
also providing the correct `uploadTaskSnapshot` key in those objects.

### Description

I noticed that when handling the promise resulting from `firebase.uploadFile()` the object being returned was incorrectly providing a key named `uploadTaskSnaphot` instead of `uploadTaskSnapshot` after wondering why I kept destructuring out an undefined value.

### Check List
If not relevant to pull request, check off as complete

- [x] All tests passing
- [x] Docs updated with any changes or examples if applicable
- [x] Added tests to ensure new feature(s) work properly

**I could not find any existing tests related to testing this return value, so I did not add any**

### Relevant Issues
<!-- * #1 -->
