### PR TITLE
Make Example Props match Proptypes

### DIFF
--- a/docs/storage.md
+++ b/docs/storage.md
@@ -60,11 +60,11 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { firebaseConnect } from 'react-redux-firebase'
 
-const Uploader = ({ deleteFile }) =>
+const Uploader = ({ firebase }) =>
   <div>
     <h1>Example File Delete</h1>
     <span>Deletes `index.txt` from storage</span>
-    <button onClick={() => deleteFile('index.txt')}>
+    <button onClick={() => firebase.deleteFile('index.txt')}>
       Delete
     </button>
   </div>


### PR DESCRIPTION
### Description

In the current example, the `Uploader` component destructures `deleteFile` directly off of `props`, but the `Uploader.propTypes` object shows that, `deleteFile` is a function on `firebase`.

### Check List
If not relevant to pull request, check off as complete

- [x] All tests passing
- [x] Docs updated with any changes or examples if applicable
- [x] Added tests to ensure new feature(s) work properly

### Relevant Issues
<!-- * #1 -->
