### PR TITLE
Fix condition in the example of Auth Recipes docs

### DIFF
--- a/docs/recipes/auth.md
+++ b/docs/recipes/auth.md
@@ -28,7 +28,7 @@ export const LoginPage = ({ firebase, auth }) => (
     <div>
       <h2>Auth</h2>
       {
-        isLoaded(auth)
+        !isLoaded(auth)
         ? <span>Loading...</span>
         : isEmpty(auth)
           ? <span>Not Authed</span>


### PR DESCRIPTION
### Description

Fix `isLoaded(auth)` condition in the Auth Recipes docs' Google Login example code.

### Check List
If not relevant to pull request, check off as complete

- [x] All tests passing
- [x] Docs updated with any changes or examples if applicable

### Relevant Issues

* #447 

