### PR TITLE
fix(docs): Bad import route for connectedRouterRedirect

### DIFF
--- a/docs/recipes/routing.md
+++ b/docs/recipes/routing.md
@@ -73,7 +73,7 @@ export const UserIsAuthenticated = UserAuthWrapper({
 
 ```javascript
 import locationHelperBuilder from 'redux-auth-wrapper/history4/locationHelper';
-import { connectedRouterRedirect } from 'redux-auth-wrapper'
+import { connectedRouterRedirect } from 'redux-auth-wrapper/history4/redirect'
 import LoadingScreen from '../components/LoadingScreen'; // change it to your custom component
 
 const locationHelper = locationHelperBuilder({});
@@ -175,7 +175,7 @@ export const UserIsNotAuthenticated = UserAuthWrapper({
 
 ```js
 import locationHelperBuilder from 'redux-auth-wrapper/history4/locationHelper';
-import { connectedRouterRedirect } from 'redux-auth-wrapper'
+import { connectedRouterRedirect } from 'redux-auth-wrapper/history4/redirect'
 
 import LoadingScreen from '../components/LoadingScreen'; // change it to your custom component
 


### PR DESCRIPTION
### Description
Fixes the docs pointing to the wrong import location for connectedRouterRedirect in redux-auth-wrapper.

The correct import was found in the redux-auth-wrapper docs: https://mjrussell.github.io/redux-auth-wrapper/docs/Getting-Started/ReactRouter4.html

### Check List
If not relevant to pull request, check off as complete

- [X] All tests passing
- [X] Docs updated with any changes or examples if applicable
- [X] Added tests to ensure new feature(s) work properly