### PR TITLE
getVal missing 'data/' in path?

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ const enhance = compose(
     ]
   }),
   connect(({ firebase }, props) => ({
-    todo: getVal(firebase, `todos/${props.params.todoId}`), // lodash's get can also be used
+    todo: getVal(firebase, `data/todos/${props.params.todoId}`), // lodash's get can also be used
   }))
 )
 


### PR DESCRIPTION
### Description
Hey I couldn't successfully get a query to work in my project following the **Query Based On Props** section. It worked once I added `data/` to the `getVal()` path so that ``getVal(firebase, `data/todos/${props.params.todoId}\`)`` as per the example you outlined in [helpers#getVal](https://react-redux-firebase.com/docs/api/helpers.html#getval). Would this be an appropriate fix, or did I miss something?

Let me know if you'd prefer me to mock-up this issue to support the PR.

### Check List
If not relevant to pull request, check off as complete

- [x] All tests passing
- [x] Docs updated with any changes or examples if applicable
- [x] Added tests to ensure new feature(s) work properly

### Relevant Issues
<!-- * #1 -->
