### PR TITLE
feat(auth): use new firebase login methods

### DIFF
--- a/src/actions/auth.js
+++ b/src/actions/auth.js
@@ -443,35 +443,31 @@ export const login = (dispatch, firebase, credentials) => {
 
   const { method, params } = getLoginMethodAndParams(firebase, credentials)
 
-  const firebaseAuth = firebase.auth()
-
-  let firebaseMethod = firebaseAuth[method]
-
-  // support older versions of firebase that still use signInWithCustomToken & signInWithEmailAndPassword
-  switch (method) {
-    case 'signInAndRetrieveDataWithCustomToken':
-      firebaseMethod = firebaseAuth.signInWithCustomToken
-      break
-    case 'signInAndRetrieveDataWithEmailAndPassword':
-      firebaseMethod = firebaseAuth.signInWithEmailAndPassword
-      break
-    default:
-      break
-  }
-
-  return firebaseMethod(...params)
+  return firebase
+    .auth()
+    [method](...params)
     .then(userData => {
       // Handle null response from getRedirectResult before redirect has happened
       if (!userData) return Promise.resolve(null)
 
       // For email auth return uid (createUser is used for creating a profile)
-      if (method === 'signInAndRetrieveDataWithEmailAndPassword') {
+      if (
+        [
+          'signInWithEmailAndPassword',
+          'signInAndRetrieveDataWithEmailAndPassword'
+        ].includes(method)
+      ) {
         return { user: userData }
       }
       // TODO: Only call createUserProfile once, and just pass different settings
 
       // For token auth, the user key doesn't exist. Instead, return the JWT.
-      if (method === 'signInAndRetrieveDataWithCustomToken') {
+      if (
+        [
+          'signInWithCustomToken',
+          'signInAndRetrieveDataWithCustomToken'
+        ].includes(method)
+      ) {
         if (!firebase._.config.updateProfileOnLogin) {
           return { user: userData }
         }

--- a/src/actions/auth.js
+++ b/src/actions/auth.js
@@ -443,15 +443,29 @@ export const login = (dispatch, firebase, credentials) => {
 
   const { method, params } = getLoginMethodAndParams(firebase, credentials)
 
-  return firebase
-    .auth()
-    [method](...params)
+  const firebaseAuth = firebase.auth()
+
+  let firebaseMethod = firebaseAuth[method]
+
+  // support older versions of firebase that still use signInWithCustomToken & signInWithEmailAndPassword
+  switch (method) {
+    case 'signInAndRetrieveDataWithCustomToken':
+      firebaseMethod = firebaseAuth.signInWithCustomToken
+      break
+    case 'signInAndRetrieveDataWithEmailAndPassword':
+      firebaseMethod = firebaseAuth.signInWithEmailAndPassword
+      break
+    default:
+      break
+  }
+
+  return firebaseMethod(...params)
     .then(userData => {
       // Handle null response from getRedirectResult before redirect has happened
       if (!userData) return Promise.resolve(null)
 
       // For email auth return uid (createUser is used for creating a profile)
-      if (method === 'signInWithEmailAndPassword') {
+      if (method === 'signInAndRetrieveDataWithEmailAndPassword') {
         return { user: userData }
       }
       // TODO: Only call createUserProfile once, and just pass different settings

--- a/src/actions/auth.js
+++ b/src/actions/auth.js
@@ -457,7 +457,7 @@ export const login = (dispatch, firebase, credentials) => {
       // TODO: Only call createUserProfile once, and just pass different settings
 
       // For token auth, the user key doesn't exist. Instead, return the JWT.
-      if (method === 'signInWithCustomToken') {
+      if (method === 'signInAndRetrieveDataWithCustomToken') {
         if (!firebase._.config.updateProfileOnLogin) {
           return { user: userData }
         }

--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -97,7 +97,13 @@ export const getLoginMethodAndParams = (firebase, creds) => {
     return { method: 'signInWithRedirect', params: [authProvider] }
   }
   if (token) {
-    return { method: 'signInAndRetrieveDataWithCustomToken', params: [token] }
+    const tokenAuth = firebase.auth().signInAndRetrieveDataWithCustomToken
+
+    if (tokenAuth) {
+      return { method: 'signInAndRetrieveDataWithCustomToken', params: [token] }
+    }
+
+    return { method: 'signInWithCustomToken', params: [token] }
   }
   if (phoneNumber) {
     if (!applicationVerifier) {
@@ -110,10 +116,18 @@ export const getLoginMethodAndParams = (firebase, creds) => {
       params: [phoneNumber, applicationVerifier]
     }
   }
-  return {
-    method: 'signInAndRetrieveDataWithEmailAndPassword',
-    params: [email, password]
+
+  const emailPasswordAuth = firebase.auth()
+    .signInAndRetrieveDataWithEmailAndPassword
+
+  if (emailPasswordAuth) {
+    return {
+      method: 'signInAndRetrieveDataWithEmailAndPassword',
+      params: [email, password]
+    }
   }
+
+  return { method: 'signInWithEmailAndPassword', params: [email, password] }
 }
 
 /**

--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -110,7 +110,10 @@ export const getLoginMethodAndParams = (firebase, creds) => {
       params: [phoneNumber, applicationVerifier]
     }
   }
-  return { method: 'signInWithEmailAndPassword', params: [email, password] }
+  return {
+    method: 'signInAndRetrieveDataWithEmailAndPassword',
+    params: [email, password]
+  }
 }
 
 /**

--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -97,7 +97,7 @@ export const getLoginMethodAndParams = (firebase, creds) => {
     return { method: 'signInWithRedirect', params: [authProvider] }
   }
   if (token) {
-    return { method: 'signInWithCustomToken', params: [token] }
+    return { method: 'signInAndRetrieveDataWithCustomToken', params: [token] }
   }
   if (phoneNumber) {
     if (!applicationVerifier) {

--- a/test/utils.js
+++ b/test/utils.js
@@ -129,7 +129,7 @@ export const fakeFirebase = {
               email: 'test@test.com',
               providerData: [{}]
             }),
-    signInWithCustomToken: () => {
+    signInAndRetrieveDataWithCustomToken: () => {
       return Promise.resolve({
         toJSON: () => ({
           stsTokenManager: {


### PR DESCRIPTION
### Description

As of [react-native-firebase v3.2.3](https://github.com/invertase/react-native-firebase/releases/tag/v3.2.3), `signInWithCustomToken` is deprecated in favour of `signInAndRetrieveDataWithCustomToken`.

![screen shot 2018-06-06 at 13 50 59](https://user-images.githubusercontent.com/6534400/41040097-59e6f718-6993-11e8-9bfb-bc5e8567c51f.png)

Found a similar issue [here](https://github.com/prescottprue/react-redux-firebase/issues/467) and implemented a fallback for users in the older version of firebase as suggested.

### Check List
- [ ] All tests passing
- [x] Docs updated with any changes or examples if applicable
- [ ] Added tests to ensure new feature(s) work properly

Fixes https://github.com/prescottprue/react-redux-firebase/issues/467