### PR TITLE
fix(docs): Auth recipe fix & API Ref link fix

### DIFF
--- a/bin/api-docs-generate.js
+++ b/bin/api-docs-generate.js
@@ -41,6 +41,10 @@ const files = [
   {
     src: 'constants.js',
     dest: 'constants.md'
+  },
+  {
+    src: 'reactReduxFirebase.js',
+    dest: 'compose.md'
   }
 ]
 

--- a/docs/recipes/auth.md
+++ b/docs/recipes/auth.md
@@ -75,7 +75,7 @@ const config = {
 
 const createStore = (initialState = {}) => {
   // Initialize Firebase instance
-  firebase.initializeApp(fbConfig)
+  firebase.initializeApp(firebaseConfig)
 
   // Add redux Firebase to compose
   const createStoreWithFirebase = createStore(
@@ -143,7 +143,7 @@ const config = {
   presence: 'presence', // where list of online users is stored in database
   sessions: 'sessions' // where list of user sessions is stored in database (presence must be enabled)
 }
-reactReduxFirebase(fbConfig, config)
+reactReduxFirebase(firebaseConfig, config)
 ```
 
 Now when logging in through `login` method, user will be listed as online until they logout or end the session (close the tab or window).

--- a/docs/recipes/auth.md
+++ b/docs/recipes/auth.md
@@ -60,14 +60,14 @@ import { compose, createStore, applyMiddleware } from 'redux'
 import { getFirebase, reactReduxFirebase } from 'react-redux-firebase'
 
 // Firebase config
-const firebaseConfig = {
+const fbConfig = {
   apiKey: '<your-api-key>',
   authDomain: '<your-auth-domain>',
   databaseURL: '<your-database-url>',
   storageBucket: '<your-storage-bucket>'
 }
 // react-redux-firebase options
-const config = {
+const rrfConfig = {
   userProfile: 'users', // firebase root where user profiles are stored
   attachAuthIsReady: true, // attaches auth is ready promise to store
   firebaseStateName: 'firebase' // should match the reducer name ('firebase' is default)
@@ -75,14 +75,14 @@ const config = {
 
 const createStore = (initialState = {}) => {
   // Initialize Firebase instance
-  firebase.initializeApp(firebaseConfig)
+  firebase.initializeApp(fbConfig)
 
   // Add redux Firebase to compose
   const createStoreWithFirebase = createStore(
     rootReducer,
     initialState,
     compose(
-      reactReduxFirebase(firebase, config),
+      reactReduxFirebase(firebase, rrfConfig),
       applyMiddleware(thunk.withExtraArgument(getFirebase))
     )
   )
@@ -138,12 +138,12 @@ The logic that runs this is partially based on:
 Include the `userProfile` parameter in config when setting up store middleware:
 
 ```js
-const config = {
+const rrfConfig = {
   userProfile: 'users', // where profiles are stored in database
   presence: 'presence', // where list of online users is stored in database
   sessions: 'sessions' // where list of user sessions is stored in database (presence must be enabled)
 }
-reactReduxFirebase(firebaseConfig, config)
+reactReduxFirebase(fbConfig, rrfConfig)
 ```
 
 Now when logging in through `login` method, user will be listed as online until they logout or end the session (close the tab or window).


### PR DESCRIPTION
### Description
There's a number of inconsistencies in naming of the firebaseConfig `fbConfig` and reactReduxFirebase `rrfConfig` variable names throughout the docs. These fixes just pertain to the Auth recipe. If I have time I will do a bigger site wide skim for inconsistencies.

Also when trying to open the `reactReduxFirebase` API ref I noticed the Markdown file for that page wasn't being compiled to html, the site is just serving `compose.md` when clicking on the link found here http://react-redux-firebase.com/docs/api/

### Check List
If not relevant to pull request, check off as complete

- [X] All tests passing
- [X] Docs updated with any changes or examples if applicable
- [X] Added tests to ensure new feature(s) work properly
