### PR TITLE
fix(auth): payload of AUTH_UPDATE_SUCCESS action dispatch fixed

### DIFF
--- a/src/actions/auth.js
+++ b/src/actions/auth.js
@@ -772,7 +772,7 @@ export const updateAuth = (dispatch, firebase, authUpdate, updateInProfile) => {
     .then(payload => {
       dispatch({
         type: actionTypes.AUTH_UPDATE_SUCCESS,
-        payload: firebase.auth().currentUser
+        auth: firebase.auth().currentUser
       })
       if (updateInProfile) {
         return updateProfile(dispatch, firebase, authUpdate)


### PR DESCRIPTION
### Description
Auth object is being reset on successful call to updateAuth. This forces users to assume logged out state.

```auth``` should be passed instead of ```payload``` on action type AUTH_UPDATE_SUCCESS

as seen on line 192 in src/reducers.js

### Check List
If not relevant to pull request, check off as complete

- [x] All tests passing
- [x] Docs updated with any changes or examples if applicable
- [x] Added tests to ensure new feature(s) work properly

### Relevant Issues
<!-- * #1 -->
