### PR TITLE
#487 fix(storage): fix downloadURL error in file upload metadata

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -40,7 +40,7 @@ const firebaseConfig = {
   databaseURL: '<your-database-url>',
   storageBucket: '<your-storage-bucket>'
 }
-firebase.initializeApp(config)
+firebase.initializeApp(firebaseConfig)
 
 // react-redux-firebase options
 const config = {

--- a/docs/recipes/upload.md
+++ b/docs/recipes/upload.md
@@ -84,14 +84,14 @@ When uploading files as in the above example, you can modify how the file's meta
 
 // within your createStore.js or store.js file include the following config
 const config = {
-  fileMetadataFactory: (uploadRes) => {
+  fileMetadataFactory: (uploadRes, firebase, metadata, downloadURL) => {
     // upload response from Firebase's storage upload
-    const { metadata: { name, fullPath, downloadURLs } } = uploadRes
+    const { metadata: { name, fullPath } } = uploadRes
     // default factory includes name, fullPath, downloadURL
     return {
       name,
       fullPath,
-      downloadURL: downloadURLs[0]
+      downloadURL
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,6 +67,22 @@
         "@babel/types": "7.0.0-beta.31"
       }
     },
+    "@babel/polyfill": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.0.0.tgz",
+      "integrity": "sha512-dnrMRkyyr74CRelJwvgnnSUDh2ge2NCTyHVwpOdvRMHtJUyxLtMAfhBN3s64pY41zdw0kgiLPh6S20eb1NcX6Q==",
+      "requires": {
+        "core-js": "^2.5.7",
+        "regenerator-runtime": "^0.11.1"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.5.7",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
+          "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
+        }
+      }
+    },
     "@babel/template": {
       "version": "7.0.0-beta.31",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.31.tgz",
@@ -15348,16 +15364,6 @@
         }
       }
     },
-    "redux-firestore": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/redux-firestore/-/redux-firestore-0.5.7.tgz",
-      "integrity": "sha512-s5eKr0BV18zBKkcuoBKQOt8QdfgrHlTz2C+/RtFKG2dOUpNtJuIsBb4aG4cCKfRklml6uX0TzT/noX+O20vv6A==",
-      "dev": true,
-      "requires": {
-        "lodash": "^4.17.10",
-        "prop-types": "^15.6.1"
-      }
-    },
     "regenerate": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.3.tgz",
@@ -15367,8 +15373,7 @@
     "regenerator-runtime": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
-      "dev": true
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
     },
     "regenerator-transform": {
       "version": "0.10.1",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "redux-react-firebase"
   ],
   "dependencies": {
+    "@babel/polyfill": "^7.0.0",
     "hoist-non-react-statics": "^2.3.1",
     "lodash": "^4.17.10",
     "prop-types": "^15.6.1"

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+import '@babel/polyfill'
 import { createFirebaseInstance } from './createFirebaseInstance'
 import firebaseConnect, { createFirebaseConnect } from './firebaseConnect'
 import firestoreConnect, { createFirestoreConnect } from './firestoreConnect'


### PR DESCRIPTION
### Description
Fixes errors I ran into when trying to save file metadata to Firestore on upload:

- Async-related error: "ReferenceError: regeneratorRuntime is not defined" is fixed by installing babel/polyfill:  [https://github.com/babel/babel/issues/5085](https://github.com/babel/babel/issues/5085)

- Syntax for returning `downloadURL` from the fileMetadataFactory has changed; updated in docs.

Also including a small fix to the 'Getting Started' docs, which I encountered when setting up a sample project to test.

### Check List
If not relevant to pull request, check off as complete

- [x] All tests passing
- [x] Docs updated with any changes or examples if applicable
- [x] Added tests to ensure new feature(s) work properly

(I did not add any tests, if needed please let me know.)

### Relevant Issues
#480 
#487 
#488
