### PR TITLE
fix(docs): fix typo on ‘preserveOnLogout’

### DIFF
--- a/docs/api/enhancer.md
+++ b/docs/api/enhancer.md
@@ -27,7 +27,7 @@ along side applyMiddleware.
         profile when logging in. (default: `true`)
     -   `config.resetBeforeLogin` **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Whether or not to empty profile
         and auth state on login
-    -   `config.perserveOnLogout` **([Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object) \| [Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array))** Data parameters to perserve
+    -   `config.preserveOnLogout` **([Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object) \| [Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array))** Data parameters to preserve
         when logging out. If Array is passed, each item represents keys
         within `state.firebase.data` to preserve. If an object is passed,
         keys associate with slices of state to preserve, and the values can be either

--- a/src/enhancer.js
+++ b/src/enhancer.js
@@ -26,7 +26,7 @@ let firebaseInstance
  * profile when logging in. (default: `true`)
  * @param {Boolean} config.resetBeforeLogin - Whether or not to empty profile
  * and auth state on login
- * @param {Object|Array} config.perserveOnLogout - Data parameters to perserve
+ * @param {Object|Array} config.preserveOnLogout - Data parameters to preserve
  * when logging out. If Array is passed, each item represents keys
  * within `state.firebase.data` to preserve. If an object is passed,
  * keys associate with slices of state to preserve, and the values can be either


### PR DESCRIPTION
### Description
Fixed typo on ‘preserveOnLogout’ and '‘preserve'

### Check List
If not relevant to pull request, check off as complete

- [x] All tests passing
- [x] Docs updated with any changes or examples if applicable
- [x] Added tests to ensure new feature(s) work properly
