### PR TITLE
feat(auth): Updated credential login to use new firebase method

### DIFF
--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -78,6 +78,14 @@ export const getLoginMethodAndParams = (firebase, creds) => {
     credential
   } = creds
   if (credential) {
+    const credentialAuth = firebase.auth().signInAndRetrieveDataWithCredential
+
+    if (credentialAuth) {
+      return {
+        method: 'signInAndRetrieveDataWithCredential',
+        params: [credential]
+      }
+    }
     return { method: 'signInWithCredential', params: [credential] }
   }
   if (provider) {


### PR DESCRIPTION
### Description

signInWithCredential is deprecated in newer versions of firebase, being replaced by signInAndRetrieveDataWithCredential, which breaks federated login using credentials

Related to [this](https://github.com/prescottprue/react-redux-firebase/issues/467) issue, and already fixed for other login methods [here](https://github.com/prescottprue/react-redux-firebase/pull/484)

### Check List
If not relevant to pull request, check off as complete

- [x] All tests passing
- [x] Docs updated with any changes or examples if applicable
- [ ] Added tests to ensure new feature(s) work properly

### Relevant Issues
#467
