### PR TITLE
Delete duplicated identifier CLEAR_ERRORS

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -37,7 +37,6 @@ export const actionTypes: {
   AUTH_RELOAD_ERROR: string
   AUTH_RELOAD_START: string
   AUTH_RELOAD_SUCCESS: string
-  CLEAR_ERRORS: string
   EMAIL_UPDATE_ERROR: string
   EMAIL_UPDATE_START: string
   EMAIL_UPDATE_SUCCESS: string


### PR DESCRIPTION
### Description

Fix this typescript compile error.

```
react-redux-firebase/index.d.ts(40,3):
TS2300: Duplicate identifier 'CLEAR_ERRORS'.
```

related #569