### PR TITLE
Fix context to Consumer instead of Provider

### DIFF
--- a/src/firebaseConnect.js
+++ b/src/firebaseConnect.js
@@ -93,7 +93,7 @@ export const createFirebaseConnect = (storeKey = 'store') => (
   const HoistedComp = hoistStatics(FirebaseConnectWrapped, WrappedComponent)
 
   const FirebaseConnect = props => (
-    <ReactReduxFirebaseContext.Provider>
+    <ReactReduxFirebaseContext.Consumer>
       {firebase => (
         <HoistedComp
           firebase={firebase}
@@ -101,7 +101,7 @@ export const createFirebaseConnect = (storeKey = 'store') => (
           {...props}
         />
       )}
-    </ReactReduxFirebaseContext.Provider>
+    </ReactReduxFirebaseContext.Consumer>
   )
 
   FirebaseConnect.propTypes = {


### PR DESCRIPTION
### Description
Wrongly used ReactReduxFirebaseContext.Provider instead of ReactReduxFirebaseContext.Consumer generates an error from React when firebaseConnect() is used.
While firestoreConnect() is using ReactReduxFirebaseContext.Consumer this is probably only a typo.

### Check List
If not relevant to pull request, check off as complete

- [X] All tests passing
- [X] Docs updated with any changes or examples if applicable
- [ ] Added tests to ensure new feature(s) work properly

### Relevant Issues
<!-- * #1 -->
