### PR TITLE
fix(storage): support only firestore when calling upload and writing to db

### DIFF
--- a/src/actions/storage.js
+++ b/src/actions/storage.js
@@ -64,7 +64,7 @@ export function uploadFile(dispatch, firebase, config) {
 
   return uploadPromise()
     .then(uploadTaskSnapshot => {
-      if (!dbPath || !firebase.database) {
+      if (!dbPath || (!firebase.database && !firebase.firestore)) {
         dispatch({
           type: FILE_UPLOAD_COMPLETE,
           meta: { ...config, filename },


### PR DESCRIPTION
### Description
When using only firestore and want to write to db to firestore. The checking is incorrect because it only consider `firebase.database` but not `firebase.firestore` when write metadata to db

### Check List
If not relevant to pull request, check off as complete

- [ ] All tests passing
- [ ] Docs updated with any changes or examples if applicable
- [ ] Added tests to ensure new feature(s) work properly

### Relevant Issues
https://github.com/prescottprue/react-redux-firebase/issues/600
