### PR TITLE
fix(createFirebaseInstance): merge internals on instance recreation

### DIFF
--- a/src/createFirebaseInstance.js
+++ b/src/createFirebaseInstance.js
@@ -1,4 +1,5 @@
 import { isObject } from 'lodash'
+import { merge } from 'lodash/fp'
 import { getEventsFromInput, createCallable } from './utils'
 import { mapWithFirebaseAndDispatch } from './utils/actions'
 import { authActions, queryActions, storageActions } from './actions'
@@ -32,12 +33,7 @@ export default function createFirebaseInstance(firebase, configs, dispatch) {
     authUid: null
   }
 
-  Object.defineProperty(firebase, '_', {
-    value: defaultInternals,
-    writable: true,
-    enumerable: true,
-    configurable: true
-  })
+  firebase._ = merge(defaultInternals, firebase._) // eslint-disable-line no-param-reassign
 
   /**
    * @private


### PR DESCRIPTION
### Description
Update `createFirebaseInstance` initialization to match `createFirestoreInstance` from `redux-firestore`. This ensures that if the instance is recreated several times, as would be the case if the provider was unmounted and remounted, it doesn't lose tracking of any existing listeners.

### Check List
If not relevant to pull request, check off as complete

- [X] All tests passing
- [X] Docs updated with any changes or examples if applicable
- [X] Added tests to ensure new feature(s) work properly

### Relevant Issues
prescottprue/redux-firestore#174
