### PR TITLE
docs(get-firebase): Fix getFirebase documentation example

### DIFF
--- a/docs/api/get-firebase.md
+++ b/docs/api/get-firebase.md
@@ -12,11 +12,12 @@ _redux-thunk integration_
 ```javascript
 import { applyMiddleware, compose, createStore } from 'redux';
 import thunk from 'redux-thunk';
-import { reactReduxFirebase } from 'react-redux-firebase';
+import firebase from 'firebase';
+import { reactReduxFirebase, getFirebase } from 'react-redux-firebase';
 import makeRootReducer from './reducers';
-import { getFirebase } from 'react-redux-firebase';
 
 const fbConfig = {} // your firebase config
+firebase.initializeApp(fbConfig)
 
 const store = createStore(
   makeRootReducer(),
@@ -26,7 +27,7 @@ const store = createStore(
       // Pass getFirebase function as extra argument
       thunk.withExtraArgument(getFirebase)
     ]),
-    reactReduxFirebase(fbConfig)
+    reactReduxFirebase(firebase)
   )
 );
 // then later


### PR DESCRIPTION
### Description

The code in `docs/api/get-firebase.md` is incorrect. This fixes it to a workable example.

### Check List
If not relevant to pull request, check off as complete

- [x] All tests passing
- [x] Docs updated with any changes or examples if applicable
- [x] Added tests to ensure new feature(s) work properly

### Relevant Issues
<!-- * #1 -->
