### PR TITLE
fix(types): arguments for "firebaseConnect"

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -448,11 +448,19 @@ export interface WithFirebaseProps<ProfileType> {
     }
 }
 
+export interface FirebaseConnectQueryObject {
+  path: string
+  type?: 'value' | 'once' | 'child_added' | 'child_removed' | 'child_changed' | 'child_moved'
+  queryParams?: string[]
+}
+
+export type FirebaseConnectQuery = (FirebaseConnectQueryObject | string)[]
+
 /**
  * React HOC that attaches/detaches Firebase Real Time Database listeners on mount/unmount
  */
 export function firebaseConnect<ProfileType, TInner = {}>(
-  connect?: mapper<TInner, string[]> | string[]
+  connect?: mapper<TInner, FirebaseConnectQuery> | FirebaseConnectQuery
 ): InferableComponentEnhancerWithProps<
   TInner & WithFirebaseProps<ProfileType>,
   WithFirebaseProps<ProfileType>


### PR DESCRIPTION
### Description

Previous, only strings were allows in `firebaseConnect` based on types.

```ts
const firebaseConnected = firebaseConnect(() => [
  'gameScores',
])
```

This PR enables using the alternative as well.

```ts
const firebaseConnected = firebaseConnect(() => [
  { path: 'gameScores' },
])
```

### Check List
If not relevant to pull request, check off as complete

- [x] All tests passing
- [x] Docs updated with any changes or examples if applicable
- [ ] Added tests to ensure new feature(s) work properly

We should probably eventually force the TS example to contain lots of different things for the sake of demonstration _and_ testing types, but seems like it's still in a very basic state anyway, so I don't think that adding these now should be a part of this PR; it will just postpone everything too long since looks like a lot of things are missing in the example anyway.

### Relevant Issues
<!-- * #1 -->

* #667 
