### PR TITLE
Types overhaul

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -453,11 +453,19 @@ export interface WithFirebaseProps<ProfileType> {
     }
 }
 
+export interface FirebaseConnectQueryObject {
+  path: string
+  type?: 'value' | 'once' | 'child_added' | 'child_removed' | 'child_changed' | 'child_moved'
+  queryParams?: string[]
+}
+
+export type FirebaseConnectQuery = (FirebaseConnectQueryObject | string)[]
+
 /**
  * React HOC that attaches/detaches Firebase Real Time Database listeners on mount/unmount
  */
 export function firebaseConnect<ProfileType, TInner = {}>(
-  connect?: mapper<TInner, string[]> | string[]
+  connect?: mapper<TInner, FirebaseConnectQuery> | FirebaseConnectQuery
 ): InferableComponentEnhancerWithProps<
   TInner & WithFirebaseProps<ProfileType>,
   WithFirebaseProps<ProfileType>

--- a/index.d.ts
+++ b/index.d.ts
@@ -364,7 +364,7 @@ interface Storage {
   ) => Promise<{ uploadTaskSnapshot: StorageTypes.UploadTaskSnapshot }[]>
 }
 
-export interface WithFirebaseProps {
+export interface WithFirebaseProps<ProfileType> {
   firebase: Auth &
     Storage & {
       initializeApp: (options: Object, name?: string) => FirebaseInstance
@@ -526,7 +526,7 @@ export function ReactReduxFirebaseProvider(
  * Props passed to ReactReduxFirebaseContext component
  */
 export interface ReactReduxFirebaseProviderProps {
-  firebase: FirebaseApp
+  firebase: FirebaseInstance
   config: Partial<ReactReduxFirebaseConfig>
   dispatch: Dispatch
   children?: React.ReactNode
@@ -630,7 +630,7 @@ export function ReduxFirestoreProvider(props: ReduxFirestoreProviderProps): any
  */
 export function withFirebase(
   ComponentToWrap: React.ComponentType
-): React.ComponentType<WithFirebaseProps>
+): React.ComponentType<WithFirebaseProps<ProfileType>>
 
 /**
  * React Higher Order Component that passes firestore as a prop (comes from context.store.firestore)


### PR DESCRIPTION
### Description

See #668.

I added back `<ProfileType>` in a few places so the file would be without errors; we can clean this up if we want later.

### Check List
If not relevant to pull request, check off as complete

- [x] All tests passing
- [x] Docs updated with any changes or examples if applicable
- [x] Added tests to ensure new feature(s) work properly

### Relevant Issues

* #667 
