### PR TITLE
Removed timestampsInSnapshots

### DIFF
--- a/docs/firestore.md
+++ b/docs/firestore.md
@@ -34,8 +34,6 @@ const firebaseConfig = {
 
 firebase.initializeApp(firebaseConfig)
 
-// Initialize Firestore with timeshot settings
-firebase.firestore().settings({ timestampsInSnapshots: true })
 
 // Add BOTH store enhancers when making store creator
 const createStoreWithFirebase = compose(


### PR DESCRIPTION
The following is no longer needed:
```
// Initialize Firestore with timeshot settings
firebase.firestore().settings({ timestampsInSnapshots: true })
```

@firebase/firestore: Firestore (5.9.1): 
  The timestampsInSnapshots setting now defaults to true and you no
  longer need to explicitly set it. In a future release, the setting
  will be removed entirely and so it is recommended that you remove it
  from your firestore.settings() call now.

### Description


### Check List
If not relevant to pull request, check off as complete

- [x] All tests passing
- [x] Docs updated with any changes or examples if applicable
- [x] Added tests to ensure new feature(s) work properly

### Relevant Issues
<!-- * #1 -->
