### PR TITLE
fix(examples): updated scripts in material example to match Readme

### DIFF
--- a/examples/complete/material/.gitignore
+++ b/examples/complete/material/.gitignore
@@ -8,6 +8,6 @@
 **/node_modules
 
 # React App
-**/dist
+**/build
 src/config.js
 .env

--- a/examples/complete/material/README.md
+++ b/examples/complete/material/README.md
@@ -45,8 +45,8 @@ While developing, you will probably rely mostly on `npm start`; however, there a
 |`npm run <script>`    |Description|
 |-------------------|-----------|
 |`start`            |Serves your app at `localhost:3000` with automatic refreshing and hot module replacement|
-|`start:dist`       |Builds the application to `./dist` then serves at `localhost:3000` using `firebase serve`|
-|`build`            |Builds the application to `./dist`|
+|`start:build`       |Builds the application to `./build` then serves at `localhost:3000` using `firebase serve`|
+|`build`            |Builds the application to `./build`|
 |`lint`             |[Lints](http://stackoverflow.com/questions/8503559/what-is-linting) the project for potential errors|
 |`lint:fix`         |Lints the project and [fixes all correctable errors](http://eslint.org/docs/user-guide/command-line-interface.html#fix)|
 

--- a/examples/complete/material/firebase.json
+++ b/examples/complete/material/firebase.json
@@ -6,7 +6,7 @@
     "rules": "storage.rules"
   },
   "hosting": {
-    "public": "dist",
+    "public": "build",
     "ignore": [
       "firebase.json",
       "**/.*",

--- a/examples/complete/material/package.json
+++ b/examples/complete/material/package.json
@@ -7,6 +7,7 @@
     "clean": "rimraf dist",
     "start": "react-scripts start",
     "build": "react-scripts build",
+    "start:build": "npm run build && firebase serve --port=3000",
     "eject": "react-scripts eject",
     "build:config": "firebase-ci createConfig",
     "deploy": "firebase-ci deploy -s",


### PR DESCRIPTION
### Description
Will change docs sections for the build script.
Will add 'start:build' script that builds the application and then serves at localhost:3000 using firebase serve.

Readme of examples/material: https://github.com/prescottprue/react-redux-firebase/tree/master/examples/complete/material#getting-started


### Check List
If not relevant to pull request, check off as complete

- [x] All tests passing
- [x] Docs updated with any changes or examples if applicable
- [x] Added tests to ensure new feature(s) work properly

### Relevant Issues
<!-- * #1 -->
