### PR TITLE
fix(docs): update broken links in multiple sections of docs

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -57,7 +57,7 @@ const createStoreWithFirebase = compose(
 const store = createStoreWithFirebase(rootReducer)
 ```
 
-View the [config section](/enhancer.html) for full list of configuration options.
+View the [config section](docs/api/enhancer) for full list of configuration options.
 
 ## Use in Components
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -88,7 +88,7 @@ export default compose(
 
 ### Decorators
 
-They are completely optional, but ES7 Decorators can be used. [The Simple Example](examples/simple) shows implementation without decorators, while [the Decorators Example](examples/decorators) shows the same application with decorators implemented.
+They are completely optional, but ES7 Decorators can be used. [The Simple Example](https://github.com/prescottprue/react-redux-firebase/blob/master/examples/complete/simple/src/Home.js) shows implementation without decorators, while [the Decorators Example](https://github.com/prescottprue/react-redux-firebase/blob/master/examples/snippets/decorators/App.js) shows the same application with decorators implemented.
 
 A side by side comparison using [react-redux](https://github.com/reactjs/react-redux)'s `connect` function/HOC is the best way to illustrate the difference:
 

--- a/examples/complete/firestore/README.md
+++ b/examples/complete/firestore/README.md
@@ -66,7 +66,7 @@ Your app is ready to be deployed!
 
 ### Integrating Auth
 
-Checkout [the auth recipes](/docs/recipes/auth) for some simple examples of how to integrate auth.
+Checkout [the auth recipes](../../../docs/recipes/auth.md) for some simple examples of how to integrate auth.
 
 **Warning**: You need to handle the loading state of auth! The recipes go over this, [but as mentioned in this issue here](https://github.com/prescottprue/react-redux-firebase/issues/93), it can seem unclear initially.
 

--- a/examples/complete/simple/README.md
+++ b/examples/complete/simple/README.md
@@ -65,6 +65,6 @@ Your app is ready to be deployed!
 
 ### Integrating Auth
 
-Checkout [the auth recipes](/docs/recipes/auth) for some simple examples of how to integrate auth.
+Checkout [the auth recipes](../../../docs/recipes/auth.md) for some simple examples of how to integrate auth.
 
 **Warning**: You need to handle the loading state of auth! The recipes go over this, [but as mentioned in this issue here](https://github.com/prescottprue/react-redux-firebase/issues/93), it can seem unclear initially.


### PR DESCRIPTION
### Description
Will fix the broken links of examples and config options in the getting started section of docs.
Will fix the auth-recipes link in examples Readme.

### Check List
If not relevant to pull request, check off as complete

- [x] All tests passing
- [x] Docs updated with any changes or examples if applicable
- [x] Added tests to ensure new feature(s) work properly

### Relevant Issues
<!-- * #1 -->
