### PR TITLE
fix(tests): replace instances of "to.equal" with "to.be" in tests - @Shalinit3

### DIFF
--- a/test/unit/actions/auth.spec.js
+++ b/test/unit/actions/auth.spec.js
@@ -78,7 +78,7 @@ describe('Actions: Auth -', () => {
     it('calls profile unwatch', () => {
       fakeFirebase._.profileWatch = () => {}
       unWatchUserProfile(fakeFirebase)
-      expect(fakeFirebase._.profileWatch).to.equal(null)
+      expect(fakeFirebase._.profileWatch).to.be.null
     })
 
     it('calls profile watch then sets to null when useFirestoreForProfile: true', () => {
@@ -90,8 +90,8 @@ describe('Actions: Auth -', () => {
       currentFake._.config.useFirestoreForProfile = true
       currentFake.firestore = {}
       unWatchUserProfile(currentFake)
-      expect(currentFake._.profileWatch).to.equal(null)
-      expect(profileCalled).to.equal(true)
+      expect(currentFake._.profileWatch).to.be.null
+      expect(profileCalled).to.be.true
     })
   })
 

--- a/test/unit/enhancer.spec.js
+++ b/test/unit/enhancer.spec.js
@@ -113,7 +113,7 @@ describe('enhancer', () => {
       it('accepts object', async () => {
         // undefined represents snapshot
         const res = await store.firebase.update('test', { some: 'asdf' })
-        expect(res).to.equal(undefined)
+        expect(res).to.be.undefined
       })
     })
 
@@ -124,7 +124,7 @@ describe('enhancer', () => {
         })
         const after = await valAtPath('test')
         expect(after.updatedAt).to.exist
-        expect(updateRes).to.equal(undefined)
+        expect(updateRes).to.be.undefined
       })
     })
 
@@ -178,7 +178,7 @@ describe('enhancer', () => {
         await store.firebase.remove('test')
         const afterSnap = await store.firebase.ref('test').once('value')
         // confirm data was removed
-        expect(afterSnap.val()).to.equal(null)
+        expect(afterSnap.val()).to.be.null
       })
 
       it('calls onComplete on success', async () => {

--- a/test/unit/helpers.spec.js
+++ b/test/unit/helpers.spec.js
@@ -47,7 +47,7 @@ describe('Helpers:', () => {
     })
 
     it('returns null for null data', () => {
-      expect(helpers.populate(exampleData, '/missing/data', [])).to.equal(null)
+      expect(helpers.populate(exampleData, '/missing/data', [])).to.be.null
     })
 
     it('returns unpopulated data for no populates', () => {

--- a/test/unit/utils/auth.spec.js
+++ b/test/unit/utils/auth.spec.js
@@ -89,15 +89,15 @@ describe('Utils: Auth', () => {
           ...firebase,
           _: { config: { presence: 'online' }, authUid: 'test' }
         })
-      ).to.equal(undefined)
+      ).to.be.undefined
     })
 
     it('exits if database is not defined', () => {
-      expect(setupPresence(() => {}, {})).to.equal(undefined)
+      expect(setupPresence(() => {}, {})).to.be.undefined
     })
 
     it('exits if database.ServerValue', () => {
-      expect(setupPresence(() => {}, { database: {} })).to.equal(undefined)
+      expect(setupPresence(() => {}, { database: {} })).to.be.undefined
     })
   })
 })

--- a/test/unit/utils/query.spec.js
+++ b/test/unit/utils/query.spec.js
@@ -159,7 +159,7 @@ describe('Utils: Query', () => {
             `equalTo=${equalTo}`
           ])
           expect(queryParams.child).to.equal(child)
-          expect(queryParams.equalTo).to.equal(true)
+          expect(queryParams.equalTo).to.be.true
         })
         it('string containing null', () => {
           const child = 'emailAddress'
@@ -169,7 +169,7 @@ describe('Utils: Query', () => {
             `equalTo=${equalTo}`
           ])
           expect(queryParams.child).to.equal(child)
-          expect(queryParams.equalTo).to.equal(null)
+          expect(queryParams.equalTo).to.be.null
         })
         it('string containing a number', () => {
           const child = 'emailAddress'
@@ -215,9 +215,7 @@ describe('Utils: Query', () => {
   describe('orderedFromSnapshot -', () => {
     it('returns null if hasChildren is a function and is false', () => {
       const hasChildrenSpy = sinon.spy(() => false)
-      expect(orderedFromSnapshot({ hasChildren: hasChildrenSpy })).to.equal(
-        null
-      )
+      expect(orderedFromSnapshot({ hasChildren: hasChildrenSpy })).to.be.null
       expect(hasChildrenSpy).to.have.been.calledOnce
     })
 
@@ -228,7 +226,7 @@ describe('Utils: Query', () => {
     })
 
     it('returns null if ordered is an empty array', () => {
-      expect(orderedFromSnapshot({ forEach: () => ({}) })).to.equal(null)
+      expect(orderedFromSnapshot({ forEach: () => ({}) })).to.be.null
     })
 
     it('adds children to ordered if they exist', () => {


### PR DESCRIPTION
Will replace to.equal(null) with to.be.null, to.equal(undefined) with to.be.undefined and to.equal(true) with to.be.true in test cases.

### Description


### Check List
If not relevant to pull request, check off as complete

- [x] All tests passing
- [x] Docs updated with any changes or examples if applicable
- [x] Added tests to ensure new feature(s) work properly

### Relevant Issues
<!-- * #1 -->
