### PR TITLE
fix(core): add lint settings for react version to prevent warning while running lint - @Shalinit3

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -5,6 +5,12 @@ parser: babel-eslint
 extends: [standard, standard-react, prettier, prettier/react]
 plugins: [babel, react, prettier]
 
+settings: {
+  react: {
+    version: 'detect'
+  }
+}
+
 env:
   browser: true
   es6: true


### PR DESCRIPTION
Will remove the warning message(Warning: React version not specified in eslint-plugin-react settings. See https://github.com/yannickcr/eslint-plugin-react#configuration.) while running lint.

### Description


### Check List
If not relevant to pull request, check off as complete

- [x] All tests passing
- [x] Docs updated with any changes or examples if applicable
- [x] Added tests to ensure new feature(s) work properly

### Relevant Issues
<!-- * #1 -->
