### PR TITLE
fix(providers): prevent unwanted re-initialization when parent component updates - @illuminist

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "prop-types": "^15.6.2"
   },
   "peerDependencies": {
-    "react": "^16.4.0"
+    "react": "^16.8.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.2.0",

--- a/src/ReactReduxFirebaseProvider.js
+++ b/src/ReactReduxFirebaseProvider.js
@@ -13,15 +13,21 @@ function ReactReduxFirebaseProvider(props = {}) {
     initializeAuth,
     createFirestoreInstance
   } = props
-  const extendedFirebaseInstance = createFirebaseInstance(
-    firebase,
-    config,
-    dispatch
+  const extendedFirebaseInstance = React.useMemo(
+    () => {
+      const extendedFirebaseInstance = createFirebaseInstance(
+        firebase,
+        config,
+        dispatch
+      )
+      if (initializeAuth) {
+        extendedFirebaseInstance.initializeAuth()
+      }
+      return extendedFirebaseInstance
+    },
+    [firebase, config, dispatch]
   )
   // Initialize auth if not disabled
-  if (initializeAuth) {
-    extendedFirebaseInstance.initializeAuth()
-  }
   if (createFirestoreInstance) {
     return (
       <ReactReduxFirebaseContext.Provider value={extendedFirebaseInstance}>

--- a/src/ReduxFirestoreProvider.js
+++ b/src/ReduxFirestoreProvider.js
@@ -12,20 +12,27 @@ function ReduxFirestoreProvider(props = {}) {
     createFirestoreInstance,
     initializeAuth
   } = props
-  const extendedFirebaseInstance = createFirebaseInstance(
-    firebase,
-    config,
-    dispatch
+  const extendedFirestoreInstance = React.useMemo(
+    () => {
+      const extendedFirebaseInstance = createFirebaseInstance(
+        firebase,
+        config,
+        dispatch
+      )
+      const extendedFirestoreInstance = createFirestoreInstance(
+        firebase,
+        config,
+        dispatch
+      )
+      // Initialize auth if not disabled
+      if (initializeAuth) {
+        extendedFirebaseInstance.initializeAuth()
+      }
+
+      return extendedFirestoreInstance
+    },
+    [firebase, config, dispatch, createFirestoreInstance, initializeAuth]
   )
-  const extendedFirestoreInstance = createFirestoreInstance(
-    firebase,
-    config,
-    dispatch
-  )
-  // Initialize auth if not disabled
-  if (initializeAuth) {
-    extendedFirebaseInstance.initializeAuth()
-  }
   return (
     <ReduxFirestoreContext.Provider value={extendedFirestoreInstance}>
       {children}


### PR DESCRIPTION
### Description
I wrapped an extended firebase instance inside react useMemo hook in order to prevent `extendedFirebaseInstance.initializeAuth()` from being called for second time when parent component updated. And it should has improved performance since it wouldn't call `createFirebaseInstance` again to create a new and change firebase instance in the `ReactReduxFirebaseContext` which would cause  update in every component that depends on firebase instance from said context.

### Check List
If not relevant to pull request, check off as complete

- [x] All tests passing
- [x] Docs updated with any changes or examples if applicable
- [x] Added tests to ensure new feature(s) work properly

