### PR TITLE
Fix `useFirestoreConnect` type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -668,9 +668,9 @@ export function useFirestore(): ExtendedFirestoreInstance
  */
 export function useFirestoreConnect<TInner>(
   connect?:
-    | mapper<TInner, (string | ReduxFirestoreQuerySetting)[]>
-    | ReduxFirestoreQuerySetting[]
-    | string[]
+    | mapper<TInner, (string | ReduxFirestoreQuerySetting)>
+    | ReduxFirestoreQuerySetting
+    | string
 ): void
 
 export function populate(


### PR DESCRIPTION
### Description
`useFirestoreConnect` type was set to accept array of query but it should accept only single query per hook.

- [x] All tests passing
- [x] Docs updated with any changes or examples if applicable
- [x] Added tests to ensure new feature(s) work properly
