### PR TITLE
fix(HOCs): firebaseConnect/firestoreConnect type definitions missing React.FunctionalComponent    

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -19,7 +19,7 @@ export interface InferableComponentEnhancerWithProps<
   TNeedsProps
 > {
   <P extends TInjectedProps>(
-    component: React.Component<P>
+    component: React.ComponentType<P>
   ): React.ComponentType<Omit<P, keyof TInjectedProps> & TNeedsProps>
 }
 


### PR DESCRIPTION
 ### Description
Type definition of firebaseConnect/firestoreConnect is accepting only React.Component type which means only ClassComponent is acceptable. Changing React.Component to React.ComponentType will allow both ClassComponent and FunctionalComponent to be acceptable.

### Check List
If not relevant to pull request, check off as complete

- [x] All tests passing
- [x] Docs updated with any changes or examples if applicable
- [x] Added tests to ensure new feature(s) work properly

### Relevant Issues
Fix https://github.com/prescottprue/react-redux-firebase/issues/736
