### PR TITLE
fix(types): changed extended firebase instance to function

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -149,7 +149,7 @@ interface ExtendedFirebaseInstance extends DatabaseTypes.FirebaseDatabase {
     value: object | string | boolean | number,
     onComplete?: Function
   ) => Promise<DatabaseTypes.DataSnapshot>
-  
+
   /**
    * Sets data to Firebase along with meta data. Currently,
    * this includes createdAt and createdBy. *Warning* using this function
@@ -177,7 +177,7 @@ interface ExtendedFirebaseInstance extends DatabaseTypes.FirebaseDatabase {
     value: object | string | boolean | number,
     onComplete?: Function
   ) => Promise<DatabaseTypes.DataSnapshot>
-  
+
   /**
    * Pushes data to Firebase along with meta data. Currently,
    * this includes createdAt and createdBy.
@@ -220,7 +220,7 @@ interface ExtendedFirebaseInstance extends DatabaseTypes.FirebaseDatabase {
     value: object | string | boolean | number,
     onComplete?: Function
   ) => Promise<DatabaseTypes.DataSnapshot>
-  
+
   /**
    * Updates data on Firebase along with meta. *Warning*
    * using this function may have unintented consequences (setting
@@ -312,7 +312,6 @@ export function createFirebaseInstance(
   dispatch: Dispatch
 ): ExtendedFirebaseInstance & Auth & Storage
 
-
 /**
  * Function that creates a Higher Order Component which
  * automatically listens/unListens to provided firebase paths using
@@ -333,25 +332,41 @@ export function createFirebaseConnect(storeKey: string): typeof firebaseConnect
  * @param {String} [storeKey='store'] - Name of redux store which contains
  * Firebase state (state.firebase)
  */
-export function createFirestoreConnect(storeKey: string): typeof firestoreConnect
+export function createFirestoreConnect(
+  storeKey: string
+): typeof firestoreConnect
 
 export function createWithFirebase(storeKey: string): typeof withFirebase
 
 export function createWithFirestore(storeKey: string): typeof withFirestore
 
-export type QueryParamOption = 'orderByKey' | 'orderByChild' | 'orderByPriority' | 'limitToFirst' | 'limitToLast' | 'notParsed' | 'parsed'
+export type QueryParamOption =
+  | 'orderByKey'
+  | 'orderByChild'
+  | 'orderByPriority'
+  | 'limitToFirst'
+  | 'limitToLast'
+  | 'notParsed'
+  | 'parsed'
 
-export type QueryParamOptions = QueryParamOption|string[]
+export type QueryParamOptions = QueryParamOption | string[]
 
 export interface ReactReduxFirebaseQuerySetting {
   path: string
-  type?: 'value' | 'once' | 'child_added' | 'child_removed' | 'child_changed' | 'child_moved'
+  type?:
+    | 'value'
+    | 'once'
+    | 'child_added'
+    | 'child_removed'
+    | 'child_changed'
+    | 'child_moved'
   queryParams?: QueryParamOptions
   storeAs?: string
 }
 
- export type ReactReduxFirebaseQueries = (ReactReduxFirebaseQuerySetting | string)[]
-
+export type ReactReduxFirebaseQueries = (
+  | ReactReduxFirebaseQuerySetting
+  | string)[]
 
 // https://github.com/prescottprue/redux-firestore#query-options
 type WhereOptions = [string, FirestoreTypes.WhereFilterOp, any]
@@ -388,7 +403,6 @@ export interface ReduxFirestoreQuerySetting {
 
 export type ReduxFirestoreQueries = (ReduxFirestoreQuerySetting | string)[]
 
-
 /**
  * Firestore instance extended with methods which dispatch redux actions.
  * More info available in the [API section of the redux-firestore docs](https://github.com/prescottprue/redux-firestore#api).
@@ -398,7 +412,10 @@ interface ExtendedFirestoreInstance extends FirestoreTypes.FirebaseFirestore {
   get: (docPath: string | ReduxFirestoreQuerySetting) => Promise<void>
 
   // Set data to firestore. More info available [in the docs](https://github.com/prescottprue/redux-firestore#set).
-  set: (docPath: string | ReduxFirestoreQuerySetting, data: Object) => Promise<void>
+  set: (
+    docPath: string | ReduxFirestoreQuerySetting,
+    data: Object
+  ) => Promise<void>
 
   // https://github.com/prescottprue/redux-firestore#add
   add: (
@@ -462,8 +479,9 @@ interface CreateUserCredentials {
   signIn?: boolean // default true
 }
 
-type Credentials = CreateUserCredentials |
-    {
+type Credentials =
+  | CreateUserCredentials
+  | {
       provider: 'facebook' | 'google' | 'twitter'
       type: 'popup' | 'redirect'
       scopes?: string[]
@@ -498,7 +516,7 @@ interface Auth {
   ) => Promise<AuthTypes.UserInfo>
 
   // http://docs.react-redux-firebase.com/history/v3.0.0/docs/auth.html#logout
-  logout: VoidFunction
+  logout: () => Promise<void>
 
   // http://docs.react-redux-firebase.com/history/v3.0.0/docs/auth.html#resetpasswordcredentials
   resetPassword: (
@@ -578,15 +596,16 @@ interface Storage {
 }
 
 export interface WithFirebaseProps<ProfileType> {
-  firebase: Auth &
-    Storage & ExtendedFirebaseInstance
+  firebase: Auth & Storage & ExtendedFirebaseInstance
 }
 
 /**
  * React HOC that attaches/detaches Firebase Real Time Database listeners on mount/unmount
  */
 export function firebaseConnect<ProfileType, TInner = {}>(
-  connect?: mapper<TInner, ReactReduxFirebaseQueries> | ReactReduxFirebaseQueries
+  connect?:
+    | mapper<TInner, ReactReduxFirebaseQueries>
+    | ReactReduxFirebaseQueries
 ): InferableComponentEnhancerWithProps<
   TInner & WithFirebaseProps<ProfileType>,
   WithFirebaseProps<ProfileType>
@@ -645,10 +664,12 @@ export function useFirebase(): ExtendedFirebaseInstance & Auth & Storage
  * to provided Cloud Firestore paths. Make sure you have required/imported
  * Cloud Firestore, including it's reducer, before attempting to use.
  * @param queriesConfig - An object or string for paths to sync
- * from firestore. Can also be a function that returns the object or string. 
+ * from firestore. Can also be a function that returns the object or string.
  */
 export function useFirebaseConnect<TInner>(
-  connect?: mapper<TInner, ReactReduxFirebaseQueries> | ReactReduxFirebaseQueries
+  connect?:
+    | mapper<TInner, ReactReduxFirebaseQueries>
+    | ReactReduxFirebaseQueries
 ): void
 
 /**
@@ -664,7 +685,7 @@ export function useFirestore(): ExtendedFirestoreInstance
  * to provided Cloud Firestore paths. Make sure you have required/imported
  * Cloud Firestore, including it's reducer, before attempting to use.
  * @param queriesConfig - An object or string for paths to sync
- * from firestore. Can also be a function that returns the object or string. 
+ * from firestore. Can also be a function that returns the object or string.
  */
 export function useFirestoreConnect<TInner>(
   connect?:
@@ -813,7 +834,6 @@ export namespace authIsReady {
 export namespace createFirebaseConnect {
   const prototype: {}
 }
-
 
 // Your Firebase/Firestore user profile object type
 // http://docs.react-redux-firebase.com/history/v3.0.0/docs/recipes/profile.html

--- a/index.d.ts
+++ b/index.d.ts
@@ -133,7 +133,7 @@ interface RemoveOptions {
 interface ExtendedFirebaseInstance extends DatabaseTypes.FirebaseDatabase {
   initializeAuth: VoidFunction
 
-  firestore: ExtendedFirestoreInstance
+  firestore: () => ExtendedFirestoreInstance
 
   dispatch: Dispatch
 


### PR DESCRIPTION
### Description
This fixes a small type error on `ExtendedFirebaseInstance` from

```javascript
  firestore: ExtendedFirestoreInstance
```
to

```javascript
  firestore: () => ExtendedFirestoreInstance
``` 

and also fixes the return type of the `logout` function from

```javascript
  logout: VoidFunction;
``` 
to

```javascript
  logout: () => Promise<void>
```



### Check List
If not relevant to pull request, check off as complete

- [x] All tests passing
- [ ] Docs updated with any changes or examples if applicable
- [ ] Added tests to ensure new feature(s) work properly

### Relevant Issues
<!-- * #1 -->
