### PR TITLE
feat(profile): add promise support for profileFactory

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -84,3 +84,25 @@ It is often convenient to run a local version of `react-redux-firebase` within a
   **What Happened?**
 
   This error most often appears due to Webpack config. A common pattern is to provide `exclude: [/node_modules/]` setting to [babel-loader](https://github.com/babel/babel-loader), which keeps the loader from transforming code within the `node_modules` folder. Now that we have used `npm link`, your project points to your local version of `react-redux-firebase` instead of the one in your `node_modules` folder, so we have to tell the loader to also exclude transforming `react-redux-firebase`.
+
+* `Invalid hook call. Hooks can only be called inside of the body of a function component`:
+
+  **Common Solution**
+
+  Add `react` as an alias in Webpack:
+  
+  **Webpack**
+  
+  ```js
+  {
+    resolve: {  
+      alias: {  
+        react: path.resolve('./node_modules/react')
+      }
+    }
+  }
+  ```
+    
+  **What Happened?**
+  
+  This error often occurs when you have multiple instances of React loading after using `npm link`. The easiest fix is by setting React as an alias in Webpack.

--- a/package-lock.json
+++ b/package-lock.json
@@ -6108,7 +6108,7 @@
     },
     "browserify-rsa": {
       "version": "4.0.1",
-      "resolved": "http://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "dev": true,
       "requires": {
@@ -6142,7 +6142,7 @@
     },
     "buffer": {
       "version": "4.9.1",
-      "resolved": "http://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
       "dev": true,
       "requires": {
@@ -6593,7 +6593,7 @@
     "circular-json": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
-      "integrity": "sha1-gVyZ6oT2gJUp0vRXkb34JxE1LWY=",
+      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
       "dev": true
     },
     "class-utils": {
@@ -8640,7 +8640,7 @@
     "eslint-plugin-node": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-5.2.1.tgz",
-      "integrity": "sha1-gN8yU8TXkBBF7If6ZgooTjK9yik=",
+      "integrity": "sha512-xhPXrh0Vl/b7870uEbaumb2Q+LxaEcOQ3kS1jtIXanBAwpMre1l5q/l2l/hESYJGEFKuI78bp6Uw50hlpr7B+g==",
       "dev": true,
       "requires": {
         "ignore": "^3.3.6",
@@ -11571,7 +11571,7 @@
     "inquirer": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
-      "integrity": "sha1-ndLyrXZdyrH/BEO0kUQqILoifck=",
+      "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
       "dev": true,
       "requires": {
         "ansi-escapes": "^3.0.0",
@@ -11631,7 +11631,7 @@
         "string-width": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
             "is-fullwidth-code-point": "^2.0.0",
@@ -12054,7 +12054,7 @@
     "jest-docblock": {
       "version": "21.2.0",
       "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-21.2.0.tgz",
-      "integrity": "sha1-UVKcOzDV/RWdpgwnzu3Blfr41BQ=",
+      "integrity": "sha512-5IZ7sY9dBAYSV+YjQ0Ovb540Ku7AO9Z5o2Cg789xj167iQuZ2cG+z0f3Uct6WeYLbU6aQiM2pCs7sZ+4dotydw==",
       "dev": true
     },
     "js-levenshtein": {
@@ -19780,7 +19780,7 @@
     "pluralize": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
-      "integrity": "sha1-KYuJ34uTsCIdv0Ia0rGx6iP8Z3c=",
+      "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
       "dev": true
     },
     "pn": {
@@ -21172,7 +21172,7 @@
     "slice-ansi": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
-      "integrity": "sha1-BE8aSdiEL/MHqta1Be0Xi9lQE00=",
+      "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
       "dev": true,
       "requires": {
         "is-fullwidth-code-point": "^2.0.0"
@@ -21782,7 +21782,7 @@
     "table": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
-      "integrity": "sha1-ozRHN1OR52atNNNIbm4q7chNLjY=",
+      "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
       "dev": true,
       "requires": {
         "ajv": "^5.2.3",
@@ -21834,7 +21834,7 @@
         "string-width": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
             "is-fullwidth-code-point": "^2.0.0",
@@ -22163,7 +22163,7 @@
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha1-bTQzWIl2jSGyvNoKonfO07G/rfk=",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "dev": true,
       "requires": {
         "os-tmpdir": "~1.0.2"
@@ -22376,7 +22376,7 @@
     },
     "tty-browserify": {
       "version": "0.0.0",
-      "resolved": "http://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
       "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
       "dev": true
     },

--- a/src/actions/auth.js
+++ b/src/actions/auth.js
@@ -273,7 +273,12 @@ export const watchUserProfile = (dispatch, firebase) => {
  * @returns {Promise} Resolves after creating user profile
  * @private
  */
-export const createUserProfile = (dispatch, firebase, userData, profile) => {
+export const createUserProfile = async (
+  dispatch,
+  firebase,
+  userData,
+  profile
+) => {
   const { _: { config } } = firebase
   if (!config.userProfile || (!firebase.database && !firebase.firestore)) {
     return Promise.resolve(userData)
@@ -282,7 +287,7 @@ export const createUserProfile = (dispatch, firebase, userData, profile) => {
   if (typeof config.profileFactory === 'function') {
     // catch errors in user provided profileFactory function
     try {
-      profile = config.profileFactory(userData, profile, firebase) // eslint-disable-line no-param-reassign
+      profile = await config.profileFactory(userData, profile, firebase) // eslint-disable-line no-param-reassign
     } catch (err) {
       /* eslint-disable no-console */
       console.error(


### PR DESCRIPTION
- feat(createUserProfile) Adding async to functionality to make firebase useful in profileFactory
- docs(Contributing) Adding new troubleshooting section for people struggling to NPM link react-redux-firebase (with two versions of React).

### Description

I realised that simply adding a third parameter "firebase" to profileFactory was not enough to make it useful. It's helpful to have createUserProfile awaiting the results of profileFactory. 

An example use case would be an "invited team user" without an account. On signup, it's useful to check for invited users, merge their profile data & assign with the correct roles & team.

### Check List
If not relevant to pull request, check off as complete

- [x] All tests passing
- [x] Docs updated with any changes or examples if applicable
- [ ] Added tests to ensure new feature(s) work properly
