### PR TITLE
fix(docs): change unused history const to browserHistory in routing example

### DIFF
--- a/docs/recipes/routing.md
+++ b/docs/recipes/routing.md
@@ -58,7 +58,7 @@ import createHistory from 'history/createBrowserHistory'
 import LoadingScreen from 'components/LoadingScreen'; // change it to your custom component
 
 const locationHelper = locationHelperBuilder({});
-const history = createHistory()
+const browserHistory = createHistory()
 
 export const UserIsAuthenticated = connectedRouterRedirect({
   wrapperDisplayName: 'UserIsAuthenticated',


### PR DESCRIPTION
### Description
Minor change to the routing doc to change the`history`, which is unused, to `browserHistory`, which is used.

### Check List
If not relevant to pull request, check off as complete

- [x] All tests passing
- [x] Docs updated with any changes or examples if applicable
- [x] Added tests to ensure new feature(s) work properly

### Relevant Issues
<!-- * #1 -->
