### PR TITLE
fix(profile): prevent `cannot read property '_getservice' of   undefined` error

### DIFF
--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -232,8 +232,8 @@ export function createAuthIsReady(store, config) {
  * @returns {Promise} Resolves with results of profile get
  */
 export function updateProfileOnRTDB(firebase, profileUpdate) {
-  const { database, _: { config, authUid } } = firebase
-  const profileRef = database().ref(`${config.userProfile}/${authUid}`)
+  const { _: { config, authUid } } = firebase
+  const profileRef = firebase.database().ref(`${config.userProfile}/${authUid}`)
   return profileRef.update(profileUpdate).then(() => profileRef.once('value'))
 }
 


### PR DESCRIPTION
This fixes a bug where calling
```javascript
firebase = useFirebase()
firebase.updateProfile(..)
```

would result in a:
```
TypeError: Cannot read property '_getService' of undefined
```

insides firebase because the 'this' keyword would be undefined, caused by the destructured `database` function.