### PR TITLE
fix(types): add missing config key `enableClaims` - @lesmo

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1000,6 +1000,7 @@ interface ReactReduxFirebaseConfig {
   userProfile: string | null
   // Use Firestore for Profile instead of Realtime DB
   useFirestoreForProfile?: boolean
+  enableClaims?: boolean
 }
 
 /**


### PR DESCRIPTION
### Description
Linters would fail when using `rffConfig.enableClaims` [as documented](http://react-redux-firebase.com/docs/auth.html#custom-claims)

### Check List
If not relevant to pull request, check off as complete

- [x] All tests passing
   _(Nothing changed)_
- [x] Docs updated with any changes or examples if applicable
   _(Already documented)_
- [x] Added tests to ensure new feature(s) work properly
   _(Not needed)_

### Relevant Issues
_(Apprently, none)_
