### PR TITLE
feat(types): add support for typed db schema

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1132,7 +1132,9 @@ export namespace FirebaseReducer {
     profile: Profile<ProfileType>
     authError: any
     data: { [T in keyof Schema]: Record<string, Schema[T]> }
-    ordered: Ordered<any>
+    ordered: {
+      [T in keyof Schema]: Array<{ key: string; value: Schema[T] }>
+    }
     errors: any[]
     isInitializing: boolean
     listeners: Listeners

--- a/index.d.ts
+++ b/index.d.ts
@@ -805,10 +805,15 @@ export function firebaseConnect<ProfileType, TInner = {}>(
  * @param action.data - Data associated with action
  * @see https://react-redux-firebase.com/docs/api/reducer.html
  */
-export function firebaseReducer<UserType>(
-  state: any,
-  action: any
-): FirebaseReducer.Reducer<UserType>
+export function firebaseReducer<
+  Schema extends Record<string, Record<string | number, string | number>>,
+  UserType
+>(state: any, action: any): FirebaseReducer.Reducer<Schema, UserType>
+
+export function makeFirebaseReducer<
+  Schema extends Record<string, Record<string | number, string | number>>,
+  UserType = {}
+>(): (state: any, action: any) => FirebaseReducer.Reducer<Schema, UserType>
 
 /**
  * React HOC that attaches/detaches Cloud Firestore listeners on mount/unmount
@@ -1119,11 +1124,14 @@ export interface Data<T extends FirestoreTypes.DocumentData> {
 }
 
 export namespace FirebaseReducer {
-  export interface Reducer<ProfileType = {}> {
+  export interface Reducer<
+    Schema extends Record<string, Record<string | number, string | number>>,
+    ProfileType = {}
+  > {
     auth: AuthState
     profile: Profile<ProfileType>
     authError: any
-    data: Data<any | Dictionary<any>>
+    data: { [T in keyof Schema]: Record<string, Schema[T]> }
     ordered: Ordered<any>
     errors: any[]
     isInitializing: boolean


### PR DESCRIPTION
### Description
For now, loose typings for state make it unsafe to use with typescript. I've added additional type parameter to state, defining `Schema` for database. Consider:
```ts
interface Todo {
  description: string;
}

// create schema for the DB
interface DBSchema {
  todos: Todo;
}

const rootReducer = combineReducers({
  firebase: makeFirebaseReducer<DBSchema>()  // new API for passing type parameter
})

type AppState = ReturnType<typeof rootReducer>;
``` 
Now if we create a selector...
```ts
export const firebaseSelector = (state: AppState) => state.firebase;

export const allItemsSelector = createSelector(
  firebaseSelector,
  firebase => firebase.data.todos
);
```
we are getting autocompletion!:
![image](https://user-images.githubusercontent.com/26183214/71920308-c218b800-3186-11ea-808d-8fb48ab551c2.png)

... and proper inner type!
![image](https://user-images.githubusercontent.com/26183214/71920412-f7bda100-3186-11ea-9af1-bea8983893ab.png)

Of course, I am open to suggestions, but I literally made the smallest possible change that allowed me to get these features (and not to crash types).