### PR TITLE
fix(auth): remove stale profile listener on empty auth state change - @illuminist - #508, #838

### DIFF
--- a/src/actions/auth.js
+++ b/src/actions/auth.js
@@ -387,6 +387,8 @@ const handleAuthStateChange = (dispatch, firebase, authData) => {
       type: actionTypes.AUTH_EMPTY_CHANGE,
       preserve: config.preserveOnEmptyAuthChange
     })
+
+    unWatchUserProfile(firebase)
   } else {
     firebase._.authUid = authData.uid // eslint-disable-line no-param-reassign
 


### PR DESCRIPTION
### Description
If using `userProfile` and listening path is restricted with security rules, the profile listener will stay subscribed and cause permission error when user logged out. This initially can be prevented by using `firebase.logout` which has a call to unwatch user profile, however, there is some case that firebase will force user to logout, for example, logging out via other tab. This can't be prevented by using `firebase.logout` because `auth.onAuthStateChanged` is being trigger by firebase itself.

I have tested with pure firebase sdk, and found out that unwatching user profile inside of `auth.onAuthStateChanged` can fixed the issue from stale listener.

### Check List
If not relevant to pull request, check off as complete

- [x] All tests passing
- [x] Docs updated with any changes or examples if applicable
- [x] Added tests to ensure new feature(s) work properly

### Relevant Issues
- https://github.com/prescottprue/react-redux-firebase/issues/838
- https://github.com/prescottprue/react-redux-firebase/issues/508