### PR TITLE
Throw error for auth init if firebase/auth isn't imported

### DIFF
--- a/src/actions/auth.js
+++ b/src/actions/auth.js
@@ -454,9 +454,7 @@ export const handleRedirectResult = (dispatch, firebase, authData) => {
 export const init = (dispatch, firebase) => {
   // exit if auth does not exist
   if (!firebase.auth) {
-    throw new Error(
-      '"firebase/auth" must be imported to enable authentication'
-    )
+    throw new Error('"firebase/auth" must be imported to enable authentication')
   }
   dispatch({ type: actionTypes.AUTHENTICATION_INIT_STARTED })
   // Set Auth State listener

--- a/src/actions/auth.js
+++ b/src/actions/auth.js
@@ -454,7 +454,9 @@ export const handleRedirectResult = (dispatch, firebase, authData) => {
 export const init = (dispatch, firebase) => {
   // exit if auth does not exist
   if (!firebase.auth) {
-    return
+    throw new Error(
+      '"firebase/auth" must be imported to enable authentication'
+    )
   }
   dispatch({ type: actionTypes.AUTHENTICATION_INIT_STARTED })
   // Set Auth State listener

--- a/test/unit/actions/auth.spec.js
+++ b/test/unit/actions/auth.spec.js
@@ -79,6 +79,7 @@ describe('Actions: Auth -', () => {
       const { auth, ...authlessFirebase } = fakeFirebase
       expect(() => init(dispatch, authlessFirebase)).to.throw()
     })
+  })
 
   describe('unWatchUserProfile -', () => {
     it('calls profile unwatch', () => {

--- a/test/unit/actions/auth.spec.js
+++ b/test/unit/actions/auth.spec.js
@@ -73,9 +73,12 @@ describe('Actions: Auth -', () => {
       expect(onAuthStateChangedSpy).to.have.been.calledOnce
     })
     it('Errors if Firebase instance is not passed', () => {
-      expect(init(dispatch, {})).to.Throw
+      expect(() => init(dispatch, {})).to.throw()
     })
-  })
+    it("Error if 'auth' doesn't exist in firebase", () => {
+      const { auth, ...authlessFirebase } = fakeFirebase
+      expect(() => init(dispatch, authlessFirebase)).to.throw()
+    })
 
   describe('unWatchUserProfile -', () => {
     it('calls profile unwatch', () => {


### PR DESCRIPTION
### Description
https://github.com/prescottprue/react-redux-firebase/issues/796

I make it to throw an error instead. Reason is if user intented to use auth, they should import `firebase/auth` instead of just warn them.

Also I found that the test code has  some misused of chai expect throw function which should make previous auth test case for error invalided.

### Check List
If not relevant to pull request, check off as complete

- [x] All tests passing
- [x] Docs updated with any changes or examples if applicable
- [x] Added tests to ensure new feature(s) work properly

### Relevant Issues
https://github.com/prescottprue/react-redux-firebase/issues/796