### PR TITLE
fix(examples): add firebase as a dependency to complete/simple example

### DIFF
--- a/examples/complete/simple/package.json
+++ b/examples/complete/simple/package.json
@@ -9,6 +9,7 @@
     "eject": "react-scripts eject"
   },
   "dependencies": {
+    "firebase": "^7.8.2",
     "prop-types": "^15.7.2",
     "react": "16.10.0",
     "react-dom": "16.10.0",


### PR DESCRIPTION
### Description
If you attempt to run the simple example, you will get this error:

![image](https://user-images.githubusercontent.com/857664/74542707-efc8ed80-4ef8-11ea-9620-050086b14f83.png)

It's pretty easily solved by the change in this PR.

### Check List
If not relevant to pull request, check off as complete

- [x] All tests passing
- [x] Docs updated with any changes or examples if applicable
- [x] Added tests to ensure new feature(s) work properly

### Relevant Issues
Not applicable.  I didn't file an issue for this.  Let me know if there needs to be one.
