### PR TITLE
fix(populate): handle firestore list type in populate

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -190,7 +190,8 @@ export function fixPath(path) {
  * @returns {object} List of child objects
  */
 function buildChildList(state, list, p) {
-  return mapValues(list, (val, key) => {
+  const mapFn = Array.isArray(list) ? map : mapValues
+  return mapFn(list, (val, key) => {
     let getKey = val
     // Handle key: true lists
     if (val === true || p.populateByKey) {

--- a/test/mockData.js
+++ b/test/mockData.js
@@ -11,7 +11,8 @@ export const exampleData = {
         collaborators: {
           ABC: true,
           abc: true
-        }
+        },
+        userRank: ['user2', 'ABC']
       },
       GHI: {
         owner: 'ABC',
@@ -59,6 +60,9 @@ export const exampleData = {
     users: {
       ABC: {
         displayName: 'scott'
+      },
+      user2: {
+        displayName: 'User2Name'
       }
     },
     categories: {

--- a/test/unit/helpers.spec.js
+++ b/test/unit/helpers.spec.js
@@ -153,13 +153,24 @@ describe('Helpers:', () => {
           rootName = 'users'
         })
 
-        it('populates values', () => {
+        it('populates values by rtdb or firestore Map type', () => {
           path = 'projects/OKF'
           populates = [{ child: 'collaborators', root: rootName }]
           const populatedData = helpers.populate(exampleData, path, populates)
           expect(populatedData).to.have.deep.property(
             `collaborators.ABC.displayName`,
             exampleData.data[rootName].ABC.displayName
+          )
+        })
+
+        it('populates values by firestore List type', () => {
+          path = 'projects/CDF'
+          populates = [{ child: 'userRank', root: rootName }]
+          const populatedData = helpers.populate(exampleData, path, populates)
+          expect(populatedData.userRank).to.be.instanceof(Array)
+          expect(populatedData).to.have.deep.property(
+            `userRank.0.displayName`,
+            exampleData.data[rootName].user2.displayName
           )
         })
       })


### PR DESCRIPTION
### Description
I understand that populate was designed for RTDB where it doesn't actually have list type for an array, thus when using with firestore list type(array), it outputs an object with index as a key instead of an actual array. So this little change fixes `populate` to be able to handle firestore list and it will output an array instead of plain object.

### Check List
If not relevant to pull request, check off as complete

- [x] All tests passing
- [x] Docs updated with any changes or examples if applicable
- [x] Added tests to ensure new feature(s) work properly

### Relevant Issues
<!-- * #1 -->
