### PR TITLE
fix(docs): use correct variable in firestore example

### DIFF
--- a/docs/firestore.md
+++ b/docs/firestore.md
@@ -120,7 +120,7 @@ Firestore queries can be created in two ways:
     useFirestoreConnect(() => [
       { collection: 'todos', doc: todoId } // or `todos/${props.todoId}`
     ])
-    const todos = useSelector(({ firestore: { ordered } }) => ordered.todos && ordered.todos[todoId])
+    const todo = useSelector(({ firestore: { ordered } }) => ordered.todos && ordered.todos[todoId])
   }
   ```
 


### PR DESCRIPTION
Minor tweak.  Since this useSelect() returns just one item, change the variable name to make its use clearer.

### Description


### Check List
If not relevant to pull request, check off as complete

- [ ] All tests passing
- [ ] Docs updated with any changes or examples if applicable
- [ ] Added tests to ensure new feature(s) work properly

### Relevant Issues
<!-- * #1 -->
