### PR TITLE
fix(docs): correct state selector in firestore example - @gregfenton

### DIFF
--- a/docs/firestore.md
+++ b/docs/firestore.md
@@ -120,7 +120,7 @@ Firestore queries can be created in two ways:
     useFirestoreConnect(() => [
       { collection: 'todos', doc: todoId } // or `todos/${props.todoId}`
     ])
-    const todo = useSelector(({ firestore: { ordered } }) => ordered.todos && ordered.todos[todoId])
+    const todo = useSelector(({ firestore: { ordered } }) => ordered.todos && ordered.todos[0])
   }
   ```
 

--- a/docs/firestore.md
+++ b/docs/firestore.md
@@ -120,7 +120,7 @@ Firestore queries can be created in two ways:
     useFirestoreConnect(() => [
       { collection: 'todos', doc: todoId } // or `todos/${props.todoId}`
     ])
-    const todo = useSelector(({ firestore: { ordered } }) => ordered.todos && ordered.todos[0])
+    const todo = useSelector(({ firestore: { data } }) => data.todos && data.todos[todoId])
   }
   ```
 


### PR DESCRIPTION
Suggested tweak to example code.  The query already limits to fetching one specific document (doc: todoId), so the result set will have just a single entry in the todos array.  I'm not even sure if ordered.todos[todoId] would even work - my brief testing shows that it would yield undefined ?

### Description


### Check List
If not relevant to pull request, check off as complete

- [ ] All tests passing
- [ ] Docs updated with any changes or examples if applicable
- [ ] Added tests to ensure new feature(s) work properly

### Relevant Issues
<!-- * #1 -->
