### PR TITLE
fix(docs): update protocol of gitter link in FAQ

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -43,4 +43,4 @@
   * Post Issues
   * Create Pull Requests
 
-[gitter-url]: gitter.im/redux-firebase/Lobby
+[gitter-url]: https://gitter.im/redux-firebase/Lobby


### PR DESCRIPTION
Fixed gitter-url by adding protocol.

Question to reviewers: should we update all absolute URLs to have https:// as the protocol rather than http:// ?

### Description


### Check List
If not relevant to pull request, check off as complete

- [ ] All tests passing
- [ ] Docs updated with any changes or examples if applicable
- [ ] Added tests to ensure new feature(s) work properly

### Relevant Issues
<!-- * #1 -->
