### PR TITLE
fix(docs): add missing field to populate example - @gregfenton

### DIFF
--- a/docs/populate.md
+++ b/docs/populate.md
@@ -188,7 +188,6 @@ const populates = [
 const enhance = compose(
   firebaseConnect([
    { path: '/todos', populates }
-   // '/todos#populate=owner:users:email' // equivalent string notation
   ]),
   connect(
     ({ firebase }) => ({
@@ -205,6 +204,7 @@ ASDF123: {
   text: 'Some Todo Item',
   owner: "Iq5b0qK2NtgggT6U3bU6iZRGyma2",
   ownerObj: {
+    displayName: "Morty Smith",
     email: 'mortysmith@gmail.com',
   }
 }


### PR DESCRIPTION
I believe the result would not filter down to just "email", or at least the example doesn't seem to indicate how that would occur.

I also removed the "equivalent string notation" as I can't find what that would be for childAlias.  (Is there documentation of the string notation somewhere?  It seems to be embedded into the Object notation/API documentation?)

### Description


### Check List
If not relevant to pull request, check off as complete

- [ ] All tests passing
- [ ] Docs updated with any changes or examples if applicable
- [ ] Added tests to ensure new feature(s) work properly

### Relevant Issues
<!-- * #1 -->
