### PR TITLE
feat(types): generic types for firestore methods

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -451,40 +451,43 @@ interface ExtendedFirestoreInstance extends FirestoreTypes.FirebaseFirestore {
    * Get data from firestore.
    * @see https://github.com/prescottprue/redux-firestore#get
    */
-  get: (docPath: string | ReduxFirestoreQuerySetting) => Promise<void>
+  get: <T>(
+    docPath: string | ReduxFirestoreQuerySetting
+  ) => Promise<FirestoreTypes.DocumentSnapshot<Partial<T>>>
 
   /**
    * Set data to firestore.
    * @see https://github.com/prescottprue/redux-firestore#set
    */
-  set: (
+  set: <T>(
     docPath: string | ReduxFirestoreQuerySetting,
-    data: Object
-  ) => Promise<void>
+    data: Partial<T>,
+    options?: FirestoreTypes.SetOptions
+  ) => Promise<FirestoreTypes.DocumentSnapshot<Partial<T>>>
 
   /**
    * Add document to firestore.
    * @see https://github.com/prescottprue/redux-firestore#add
    */
-  add: (
+  add: <T>(
     collectionPath: string | ReduxFirestoreQuerySetting,
-    data: Object
+    data: Partial<T>
   ) => Promise<{ id: string }>
 
   /**
    * Update document within firestore.
    * @see https://github.com/prescottprue/redux-firestore#update
    */
-  update: (
+  update: <T>(
     docPath: string | ReduxFirestoreQuerySetting,
-    data: Object
-  ) => Promise<void>
+    data: Partial<T>
+  ) => Promise<FirestoreTypes.DocumentSnapshot<Partial<T>>>
 
   /**
    * Delete a document within firestore.
    * @see https://github.com/prescottprue/redux-firestore#delete
    */
-  delete: (docPath: string | ReduxFirestoreQuerySetting) => Promise<void>
+  delete: <T>(docPath: string | ReduxFirestoreQuerySetting) => Promise<T>
 
   /**
    * Executes the given updateFunction and then attempts to commit the changes applied within the


### PR DESCRIPTION
### Description
Firestore types update

1. Firestore .set allows for options to be passed as well.
2. Added typescript generics support to get/set/update/add/delete

### Check List
If not relevant to pull request, check off as complete

- [x] All tests passing
- [x] Docs updated with any changes or examples if applicable
- [x] Added tests to ensure new feature(s) work properly

### Relevant Issues
<!-- * #1 -->
