### PR TITLE
fix(docs): use correct wording in firestore query docs

### DIFF
--- a/docs/firestore.md
+++ b/docs/firestore.md
@@ -83,11 +83,11 @@ const rrfConfig = {
 
 ## Queries
 
-Firestore queries can be created in two ways:
+Firestore queries can be created in the following ways:
 
-* [Automatically with Hook](#useFirestoreConnect) - Using `useFirestoreConnect` hook (manages mounting/unmounting)
-* [Automatically with HOC](#firestoreConnect) - Using `firestoreConnect` HOC (manages mounting/unmounting)
-* [Manually](#manual) - Using `get`, or by setting listeners with `setListeners`/`setListener` (requires managing of listeners)
+1. [Automatically with Hook](#useFirestoreConnect) - Using `useFirestoreConnect` hook (manages mounting/unmounting)
+1. [Automatically with HOC](#firestoreConnect) - Using `firestoreConnect` HOC (manages mounting/unmounting)
+1. [Manually](#manual) - Using `get`, or by setting listeners with `setListeners`/`setListener` (requires managing of listeners)
 
 ### Automatically with Hook {#useFirestoreConnect}
 


### PR DESCRIPTION
Fixed tiny error

### Description


### Check List
If not relevant to pull request, check off as complete

- [ ] All tests passing
- [ ] Docs updated with any changes or examples if applicable
- [ ] Added tests to ensure new feature(s) work properly

### Relevant Issues
<!-- * #1 -->
