### PR TITLE
fix(types): use correct import for react in types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import * as FirestoreTypes from '@firebase/firestore-types'
 import * as DatabaseTypes from '@firebase/database-types'
 import * as StorageTypes from '@firebase/storage-types'


### PR DESCRIPTION
### Description

To fix the following:

```sh
node_modules/react-redux-firebase/index.d.ts:1:8 - error TS1259: Module '"/Users/danila/Projects/MyProject/node_modules/@types/react/index"' can only be default-imported using the 'esModuleInterop' flag

1 import React from 'react'
         ~~~~~

  node_modules/@types/react/index.d.ts:64:1
    64 export = React;
       ~~~~~~~~~~~~~~~
    This module is declared with using 'export =', and can only be used with a default import when using the 'esModuleInterop' flag.
```

### Check List
If not relevant to pull request, check off as complete

- [x] All tests passing
- [x] Docs updated with any changes or examples if applicable
- [x] Added tests to ensure new feature(s) work properly

### Relevant Issues
<!-- * #1 -->
