### PR TITLE
fix(docs): complete sentence under parsed (#925)

### DIFF
--- a/docs/queries.md
+++ b/docs/queries.md
@@ -501,7 +501,7 @@ firebaseConnect([
 
 #### parsed {#parsed}
 
-Internally parse following query params. Useful when attempting to parse
+Internally parse following query params. Useful when attempting to parse query parameters into the actual value or particular data type ( e.g. null, number, boolean) instead of the string containing the value.
 
 **NOTE**: `orderByChild`, `orderByPriority`, and `orderByValue` will cause this to be enabled by default. Parsing will remain enabled for the rest of the query params until `notParsed` is called.
 


### PR DESCRIPTION
### Description
On the PARSED section of the Queries page there is an incomplete sentence/thought:

>Useful when attempting to parse

I completed it to read:

>Useful when attempting to parse query parameters into the actual value or particular data type ( e.g. null, number, boolean) instead of the string containing the value. 

### Check List
If not relevant to pull request, check off as complete

- [x] All tests passing
- [x] Docs updated with any changes or examples if applicable
- [ ] Added tests to ensure new feature(s) work properly

### Relevant Issues
<!-- * #1 -->
