### PR TITLE
fix(docx): Non-matching example in Queries doc page (#935)

### DIFF
--- a/docs/queries.md
+++ b/docs/queries.md
@@ -368,7 +368,7 @@ Limit query results to the first n number of results.
 
   ```javascript
   firebaseConnect([
-    { path: '/todos', queryParams: [ 'orderByChild=createdBy', 'equalTo=123' ] }
+    { path: '/todos', queryParams: [ 'limitToFirst=10'] }
     // '/todos#limitToFirst=10' // string notation
   ])
   ```


### PR DESCRIPTION
### Description
Corrected mismatching example in Queries doc page, under limitToFirst as highlighted in the issue here: #935

### Check List
If not relevant to pull request, check off as complete

- [x] All tests passing
- [x] Docs updated with any changes or examples if applicable
- [x] Added tests to ensure new feature(s) work properly

### Relevant Issues
<!-- * #1 -->
