### PR TITLE
fix(docs): cleanup minor typo in useFirestoreConnect.md

### DIFF
--- a/docs/api/firestoreConnect.md
+++ b/docs/api/firestoreConnect.md
@@ -14,7 +14,7 @@
 
 Higher Order Component that automatically listens/unListens
 to provided Cloud Firestore paths using React's Lifecycle hooks. Make sure you
-have required/imported Cloud Firestore, including it's reducer, before
+have required/imported Cloud Firestore, including its reducer, before
 attempting to use. **Note** Populate is not yet supported.
 
 ### Parameters

--- a/docs/api/useFirestoreConnect.md
+++ b/docs/api/useFirestoreConnect.md
@@ -11,7 +11,7 @@
 
 React hook that automatically listens/unListens
 to provided Cloud Firestore paths. Make sure you have required/imported
-Cloud Firestore, including it's reducer, before attempting to use.
+Cloud Firestore, including its reducer, before attempting to use.
 **Note** Populate is not yet supported.
 
 ### Parameters


### PR DESCRIPTION
QUESTION: this page still indicates that "populate is not supported".  Is this still the case for firestore?

### Description


### Check List
If not relevant to pull request, check off as complete

- [ ] All tests passing
- [ ] Docs updated with any changes or examples if applicable
- [ ] Added tests to ensure new feature(s) work properly

### Relevant Issues
<!-- * #1 -->
