### PR TITLE
feat(docs): add firestore populate docs

### DIFF
--- a/docs/populate.md
+++ b/docs/populate.md
@@ -334,3 +334,26 @@ const config = {
   }
 }
 ```
+
+### Use with Firestore
+
+To use populate with Firestore, just replace firebaseConnect with firestoreConnect with the corresponding charaters.
+
+```javascript
+import { firestoreConnect, populate } from 'react-redux-firebase';
+
+const populates = [
+  { child: 'owner', root: 'users', childAlias: 'ownerObj' }
+]
+
+const enhance = compose(
+  firestoreConnect([
+    { collection: 'todos', populates }
+  ]),
+  connect(
+    ({ firebase }) => ({
+      todos: populate(firebase, 'todos', populates),
+    })
+  )
+)
+```


### PR DESCRIPTION
### Description
Docs do mention populate is supported in firestore.md, however the how-to was missing.

### Check List
If not relevant to pull request, check off as complete

- [ ] All tests passing
- [x] Docs updated with any changes or examples if applicable
- [ ] Added tests to ensure new feature(s) work properly

### Relevant Issues
none
