### PR TITLE
feat(types): add type predicate to isLoaded

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -912,6 +912,7 @@ export function isEmpty(...args: any[]): boolean
  * @returns Whether or not item is loaded
  * @see https://react-redux-firebase.com/docs/api/helpers.html#isloaded
  */
+export function isLoaded<T>(arg: T | null | undefined): arg is T
 export function isLoaded(...args: any[]): boolean
 
 /**


### PR DESCRIPTION
### Description
We know that if `isLoaded()` helper returns `true` the argument is not `undefined`.
I added an overload to isLoaded function type so that it will narrow type of its argument.

Unfortunately this only works for single argument (we can't have type predicates that reference spread arguments).

### Check List
If not relevant to pull request, check off as complete

- [x] All tests passing
- [x] Docs updated with any changes or examples if applicable
- [x] Added tests to ensure new feature(s) work properly

### Relevant Issues
Fixes #955
