### PR TITLE
feat(types): add database and firestore statics

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -357,24 +357,11 @@ type ExtendedFirebaseInstance = BaseExtendedFirebaseInstance & OptionalPick<Fire
  * @see https://react-redux-firebase.com/docs/api/firebaseInstance.html
  */
 export function createFirebaseInstance(
-  firebase: FirebaseNamespace,
+  firebase: any,
   configs: Partial<ReduxFirestoreConfig>,
   dispatch: Dispatch
 ): ExtendedFirebaseInstance;
 
-/**
- * Create an extended firebase instance that has methods attached
- * which dispatch redux actions.
- * @param firebase - Firebase instance which to extend
- * @param configs - Configuration object
- * @param dispatch - Action dispatch function
- * @see https://react-redux-firebase.com/docs/api/firebaseInstance.html
- */
-export function createFirebaseInstance(
-  firebase: any,
-  configs: Partial<ReduxFirestoreConfig>,
-  dispatch: Dispatch
-): ExtendedFirebaseInstance
 
 export type QueryParamOption =
   | 'orderByKey'

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { FirebaseNamespace } from "@firebase/app-types";
 import * as FirestoreTypes from '@firebase/firestore-types'
 import * as DatabaseTypes from '@firebase/database-types'
 import * as StorageTypes from '@firebase/storage-types'
@@ -160,7 +161,7 @@ interface FirebaseDatabaseService {
  * redux actions.
  * @see https://react-redux-firebase.com/docs/api/firebaseInstance.html
  */
-interface ExtendedFirebaseInstance
+interface BaseExtendedFirebaseInstance
   extends DatabaseTypes.FirebaseDatabase,
     FirebaseDatabaseService,
     ExtendedAuthInstance,
@@ -337,6 +338,29 @@ interface ExtendedFirebaseInstance
     options?: string
   ) => Promise<any>
 }
+
+/**
+ * OptionalOverride is left here in the event that any of the optional properties below need to be extended in the future.
+ * Example: OptionalOverride<FirebaseNamespace, 'messaging', { messaging: ExtendedMessagingInstance }>
+ */
+type OptionalOverride<T, b extends string, P> = b extends keyof T ? P : {};
+type OptionalPick<T, b extends string> = { [k in (b extends keyof T ? b : never)]: T[k] };
+
+type ExtendedFirebaseInstance = BaseExtendedFirebaseInstance & OptionalPick<FirebaseNamespace, 'messaging' | 'performance' | 'functions' | 'analytics' | 'remoteConfig'>
+  
+/**
+ * Create an extended firebase instance that has methods attached
+ * which dispatch redux actions.
+ * @param firebase - Firebase instance which to extend
+ * @param configs - Configuration object
+ * @param dispatch - Action dispatch function
+ * @see https://react-redux-firebase.com/docs/api/firebaseInstance.html
+ */
+export function createFirebaseInstance(
+  firebase: FirebaseNamespace,
+  configs: Partial<ReduxFirestoreConfig>,
+  dispatch: Dispatch
+): ExtendedFirebaseInstance;
 
 /**
  * Create an extended firebase instance that has methods attached

--- a/index.d.ts
+++ b/index.d.ts
@@ -140,11 +140,31 @@ interface RemoveOptions {
 }
 
 /**
+ * https://firebase.google.com/docs/reference/js/firebase.database
+ */
+
+interface FirebaseDatabaseService {
+  database: {
+    (app?: string): DatabaseTypes.FirebaseDatabase
+    Reference: DatabaseTypes.Reference
+    Query: DatabaseTypes.Query
+    DataSnapshot: DatabaseTypes.DataSnapshot
+    enableLogging: typeof DatabaseTypes.enableLogging
+    ServerValue: DatabaseTypes.ServerValue
+    Database: typeof DatabaseTypes.FirebaseDatabase
+  }
+}
+
+/**
  * Firestore instance extended with methods which dispatch
  * redux actions.
  * @see https://react-redux-firebase.com/docs/api/firebaseInstance.html
  */
-interface ExtendedFirebaseInstance extends DatabaseTypes.FirebaseDatabase {
+interface ExtendedFirebaseInstance
+  extends DatabaseTypes.FirebaseDatabase,
+    FirebaseDatabaseService,
+    ExtendedAuthInstance,
+    ExtendedStorageInstance {
   initializeAuth: VoidFunction
 
   firestore: () => ExtendedFirestoreInstance
@@ -330,7 +350,7 @@ export function createFirebaseInstance(
   firebase: any,
   configs: Partial<ReduxFirestoreConfig>,
   dispatch: Dispatch
-): ExtendedFirebaseInstance & ExtendedAuthInstance & ExtendedStorageInstance
+): ExtendedFirebaseInstance
 
 export type QueryParamOption =
   | 'orderByKey'
@@ -447,7 +467,9 @@ export type ReduxFirestoreQueriesFunction = (
  * Firestore instance extended with methods which dispatch redux actions.
  * @see https://github.com/prescottprue/redux-firestore#api
  */
-interface ExtendedFirestoreInstance extends FirestoreTypes.FirebaseFirestore {
+interface ExtendedFirestoreInstance
+  extends FirestoreTypes.FirebaseFirestore,
+    FirestoreStatics {
   /**
    * Get data from firestore.
    * @see https://github.com/prescottprue/redux-firestore#get
@@ -532,7 +554,7 @@ interface ExtendedFirestoreInstance extends FirestoreTypes.FirebaseFirestore {
  * @see https://github.com/prescottprue/redux-firestore#other-firebase-statics
  */
 interface FirestoreStatics {
-  FieldValue: FirestoreTypes.FieldValue
+  FieldValue: typeof FirestoreTypes.FieldValue
   FieldPath: FirestoreTypes.FieldPath
   setLogLevel: (logLevel: FirestoreTypes.LogLevel) => void
   Blob: FirestoreTypes.Blob
@@ -543,18 +565,14 @@ interface FirestoreStatics {
   Query: FirestoreTypes.Query
   QueryDocumentSnapshot: FirestoreTypes.QueryDocumentSnapshot
   QuerySnapshot: FirestoreTypes.QuerySnapshot
-  Timestamp: FirestoreTypes.FieldValue
+  Timestamp: typeof FirestoreTypes.FieldValue
   Transaction: FirestoreTypes.Transaction
   WriteBatch: FirestoreTypes.WriteBatch
 }
 
 export interface WithFirestoreProps {
-  firestore: FirestoreTypes.FirebaseFirestore &
-    ExtendedFirestoreInstance &
-    FirestoreStatics
-  firebase: ExtendedFirebaseInstance &
-    ExtendedAuthInstance &
-    ExtendedStorageInstance
+  firestore: ExtendedFirestoreInstance
+  firebase: ExtendedFirebaseInstance
   dispatch: Dispatch
 }
 
@@ -803,9 +821,7 @@ export interface UploadFileOptions<T extends File | Blob> {
 }
 
 export interface WithFirebaseProps<ProfileType> {
-  firebase: ExtendedAuthInstance &
-    ExtendedStorageInstance &
-    ExtendedFirebaseInstance
+  firebase: ExtendedFirebaseInstance
 }
 
 /**
@@ -878,9 +894,7 @@ export function fixPath(path: string): string
  * integrations into external libraries such as redux-thunk and redux-observable.
  * @see https://react-redux-firebase.com/docs/api/getFirebase.html
  */
-export function getFirebase(): ExtendedFirebaseInstance &
-  ExtendedAuthInstance &
-  ExtendedStorageInstance
+export function getFirebase(): ExtendedFirebaseInstance
 
 /**
  * Get a value from firebase using slash notation.  This enables an easy
@@ -919,9 +933,7 @@ export function isLoaded(...args: any[]): boolean
  * instance is gathered from `ReactReduxFirebaseContext`.
  * @see https://react-redux-firebase.com/docs/api/useFirebase.html
  */
-export function useFirebase(): ExtendedFirebaseInstance &
-  ExtendedAuthInstance &
-  ExtendedStorageInstance
+export function useFirebase(): ExtendedFirebaseInstance
 
 /**
  * React hook that automatically listens/unListens

--- a/index.d.ts
+++ b/index.d.ts
@@ -344,7 +344,7 @@ interface BaseExtendedFirebaseInstance
  * Example: OptionalOverride<FirebaseNamespace, 'messaging', { messaging: ExtendedMessagingInstance }>
  */
 type OptionalOverride<T, b extends string, P> = b extends keyof T ? P : {};
-type OptionalPick<T, b extends string> = { [k in (b extends keyof T ? b : never)]: T[k] };
+type OptionalPick<T, b extends string> = Pick<T, b & keyof T>
 
 type ExtendedFirebaseInstance = BaseExtendedFirebaseInstance & OptionalPick<FirebaseNamespace, 'messaging' | 'performance' | 'functions' | 'analytics' | 'remoteConfig'>
   


### PR DESCRIPTION
### Description

- Prefers extending the base interfaces for Firestore/FirebaseExtendedInstance instead of using intersections throughout the types
- Adds `FirebaseDatabaseService` types so that you can achieve:
```ts
...
const firebase = useFirebase();
firebase.database.ServerValue.TIMESTAMP
...
```
- Correct types for FirestoreStatics so you can achieve:
```ts
const firestore = useFirestore();
firestore.FieldValue.serverTimestamp()
```
_Previously, you would've gotten 'serverTimestamp() is a static member of FieldValue'_
- Fixes `useFirestore()` types - previously `withFirestore` would've been close, but `useFirestore` was missing statics.

We've also added inference for plugins, such as performance, analytics, remoteConfig, etc. When a user `import`s those plugins, TS will automatically allow a user to access those properties. This basically works by saying, 'if we see this known key on the `firebase` instance, use the types that we know firebase merged into the namespace'

### Check List
If not relevant to pull request, check off as complete

- [X] All tests passing
- [x] Docs updated with any changes or examples if applicable
- [X] Added tests to ensure new feature(s) work properly

### Relevant Issues
<!-- * #1 -->
