### PR TITLE
Improve types for FirestoreReducer.Reducer

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -357,24 +357,11 @@ type ExtendedFirebaseInstance = BaseExtendedFirebaseInstance & OptionalPick<Fire
  * @see https://react-redux-firebase.com/docs/api/firebaseInstance.html
  */
 export function createFirebaseInstance(
-  firebase: FirebaseNamespace,
+  firebase: any,
   configs: Partial<ReduxFirestoreConfig>,
   dispatch: Dispatch
 ): ExtendedFirebaseInstance;
 
-/**
- * Create an extended firebase instance that has methods attached
- * which dispatch redux actions.
- * @param firebase - Firebase instance which to extend
- * @param configs - Configuration object
- * @param dispatch - Action dispatch function
- * @see https://react-redux-firebase.com/docs/api/firebaseInstance.html
- */
-export function createFirebaseInstance(
-  firebase: any,
-  configs: Partial<ReduxFirestoreConfig>,
-  dispatch: Dispatch
-): ExtendedFirebaseInstance
 
 export type QueryParamOption =
   | 'orderByKey'

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { FirebaseNamespace } from "@firebase/app-types";
 import * as FirestoreTypes from '@firebase/firestore-types'
 import * as DatabaseTypes from '@firebase/database-types'
 import * as StorageTypes from '@firebase/storage-types'
@@ -160,7 +161,7 @@ interface FirebaseDatabaseService {
  * redux actions.
  * @see https://react-redux-firebase.com/docs/api/firebaseInstance.html
  */
-interface ExtendedFirebaseInstance
+interface BaseExtendedFirebaseInstance
   extends DatabaseTypes.FirebaseDatabase,
     FirebaseDatabaseService,
     ExtendedAuthInstance,
@@ -337,6 +338,29 @@ interface ExtendedFirebaseInstance
     options?: string
   ) => Promise<any>
 }
+
+/**
+ * OptionalOverride is left here in the event that any of the optional properties below need to be extended in the future.
+ * Example: OptionalOverride<FirebaseNamespace, 'messaging', { messaging: ExtendedMessagingInstance }>
+ */
+type OptionalOverride<T, b extends string, P> = b extends keyof T ? P : {};
+type OptionalPick<T, b extends string> = { [k in (b extends keyof T ? b : never)]: T[k] };
+
+type ExtendedFirebaseInstance = BaseExtendedFirebaseInstance & OptionalPick<FirebaseNamespace, 'messaging' | 'performance' | 'functions' | 'analytics' | 'remoteConfig'>
+  
+/**
+ * Create an extended firebase instance that has methods attached
+ * which dispatch redux actions.
+ * @param firebase - Firebase instance which to extend
+ * @param configs - Configuration object
+ * @param dispatch - Action dispatch function
+ * @see https://react-redux-firebase.com/docs/api/firebaseInstance.html
+ */
+export function createFirebaseInstance(
+  firebase: FirebaseNamespace,
+  configs: Partial<ReduxFirestoreConfig>,
+  dispatch: Dispatch
+): ExtendedFirebaseInstance;
 
 /**
  * Create an extended firebase instance that has methods attached

--- a/index.d.ts
+++ b/index.d.ts
@@ -140,11 +140,31 @@ interface RemoveOptions {
 }
 
 /**
+ * https://firebase.google.com/docs/reference/js/firebase.database
+ */
+
+interface FirebaseDatabaseService {
+  database: {
+    (app?: string): DatabaseTypes.FirebaseDatabase
+    Reference: DatabaseTypes.Reference
+    Query: DatabaseTypes.Query
+    DataSnapshot: DatabaseTypes.DataSnapshot
+    enableLogging: typeof DatabaseTypes.enableLogging
+    ServerValue: DatabaseTypes.ServerValue
+    Database: typeof DatabaseTypes.FirebaseDatabase
+  }
+}
+
+/**
  * Firestore instance extended with methods which dispatch
  * redux actions.
  * @see https://react-redux-firebase.com/docs/api/firebaseInstance.html
  */
-interface ExtendedFirebaseInstance extends DatabaseTypes.FirebaseDatabase {
+interface ExtendedFirebaseInstance
+  extends DatabaseTypes.FirebaseDatabase,
+    FirebaseDatabaseService,
+    ExtendedAuthInstance,
+    ExtendedStorageInstance {
   initializeAuth: VoidFunction
 
   firestore: () => ExtendedFirestoreInstance
@@ -330,7 +350,7 @@ export function createFirebaseInstance(
   firebase: any,
   configs: Partial<ReduxFirestoreConfig>,
   dispatch: Dispatch
-): ExtendedFirebaseInstance & ExtendedAuthInstance & ExtendedStorageInstance
+): ExtendedFirebaseInstance
 
 export type QueryParamOption =
   | 'orderByKey'
@@ -447,7 +467,9 @@ export type ReduxFirestoreQueriesFunction = (
  * Firestore instance extended with methods which dispatch redux actions.
  * @see https://github.com/prescottprue/redux-firestore#api
  */
-interface ExtendedFirestoreInstance extends FirestoreTypes.FirebaseFirestore {
+interface ExtendedFirestoreInstance
+  extends FirestoreTypes.FirebaseFirestore,
+    FirestoreStatics {
   /**
    * Get data from firestore.
    * @see https://github.com/prescottprue/redux-firestore#get
@@ -532,7 +554,7 @@ interface ExtendedFirestoreInstance extends FirestoreTypes.FirebaseFirestore {
  * @see https://github.com/prescottprue/redux-firestore#other-firebase-statics
  */
 interface FirestoreStatics {
-  FieldValue: FirestoreTypes.FieldValue
+  FieldValue: typeof FirestoreTypes.FieldValue
   FieldPath: FirestoreTypes.FieldPath
   setLogLevel: (logLevel: FirestoreTypes.LogLevel) => void
   Blob: FirestoreTypes.Blob
@@ -543,18 +565,14 @@ interface FirestoreStatics {
   Query: FirestoreTypes.Query
   QueryDocumentSnapshot: FirestoreTypes.QueryDocumentSnapshot
   QuerySnapshot: FirestoreTypes.QuerySnapshot
-  Timestamp: FirestoreTypes.FieldValue
+  Timestamp: typeof FirestoreTypes.FieldValue
   Transaction: FirestoreTypes.Transaction
   WriteBatch: FirestoreTypes.WriteBatch
 }
 
 export interface WithFirestoreProps {
-  firestore: FirestoreTypes.FirebaseFirestore &
-    ExtendedFirestoreInstance &
-    FirestoreStatics
-  firebase: ExtendedFirebaseInstance &
-    ExtendedAuthInstance &
-    ExtendedStorageInstance
+  firestore: ExtendedFirestoreInstance
+  firebase: ExtendedFirebaseInstance
   dispatch: Dispatch
 }
 
@@ -803,9 +821,7 @@ export interface UploadFileOptions<T extends File | Blob> {
 }
 
 export interface WithFirebaseProps<ProfileType> {
-  firebase: ExtendedAuthInstance &
-    ExtendedStorageInstance &
-    ExtendedFirebaseInstance
+  firebase: ExtendedFirebaseInstance
 }
 
 /**
@@ -878,9 +894,7 @@ export function fixPath(path: string): string
  * integrations into external libraries such as redux-thunk and redux-observable.
  * @see https://react-redux-firebase.com/docs/api/getFirebase.html
  */
-export function getFirebase(): ExtendedFirebaseInstance &
-  ExtendedAuthInstance &
-  ExtendedStorageInstance
+export function getFirebase(): ExtendedFirebaseInstance
 
 /**
  * Get a value from firebase using slash notation.  This enables an easy
@@ -919,9 +933,7 @@ export function isLoaded(...args: any[]): boolean
  * instance is gathered from `ReactReduxFirebaseContext`.
  * @see https://react-redux-firebase.com/docs/api/useFirebase.html
  */
-export function useFirebase(): ExtendedFirebaseInstance &
-  ExtendedAuthInstance &
-  ExtendedStorageInstance
+export function useFirebase(): ExtendedFirebaseInstance
 
 /**
  * React hook that automatically listens/unListens

--- a/index.d.ts
+++ b/index.d.ts
@@ -344,7 +344,7 @@ interface BaseExtendedFirebaseInstance
  * Example: OptionalOverride<FirebaseNamespace, 'messaging', { messaging: ExtendedMessagingInstance }>
  */
 type OptionalOverride<T, b extends string, P> = b extends keyof T ? P : {};
-type OptionalPick<T, b extends string> = { [k in (b extends keyof T ? b : never)]: T[k] };
+type OptionalPick<T, b extends string> = Pick<T, b & keyof T>
 
 type ExtendedFirebaseInstance = BaseExtendedFirebaseInstance & OptionalPick<FirebaseNamespace, 'messaging' | 'performance' | 'functions' | 'analytics' | 'remoteConfig'>
   


### PR DESCRIPTION
### Description
Expands on #957. Allows `order` and `data` to be correctly typed when there are nested collections/schemas. I can merge this into that branch once I get feedback on the below. Here is a [TS playground](https://www.typescriptlang.org/play/#code/JYWwDg9gTgLgBAKjgQwM5wGLCgU1TaHAFQE8w84AzKCEOAcgAFLscAjNHAehd30IC0MMnnoAoMTgAekWHAB2yEHjDIAxjkyt+uAEo4AJgFcNUOAG8xca3AM41AG2S44aiPPxwc8mMGEBlEhA2CAcALjgjeWAARyNNVCCQhwBuCRsvGWh4YXI4AFEfPxIAHiIAPjgAXmsiOAAyCysMmwBtb18ApNCAXQj5HAA3HCg0jIBfdJtpWRyRAqLhAHU-AAsASQMyypq6xvM4YAMI-ChgeQBzOEnm61zNABFkGGQS-zVVnBBkTJhvA3Q+jcUC2p3OFwANCh5CRyjs4LcWgdWnVznAANY4EgQShwd6fb59axA6CgmBnS5QvEfL7IFE9X7-dCFTqlc6UEZwABqlQA-Ny4BEni83jTvvS4dcpnd5gB5EEjQzC1742mM+QAuAkkElMGU6GwnaIjLI1HyDFYnHUgnIImq8VEBnSP4a5mLNnyDlmHlwfks4orGAbLY81oMiLyuy4AzKkr+5ZrTaim0S8phqWImbZQ4+EaUdSafTGUwlY02e0-Z1MrX2Um68ngqHIGHw8yTFo2SqWDvWAzPZBC-vJ2nlMvWUmK45wSOT2MV0cTMQ3DLnP5QfMaLR8Ai4IhodEWBE9qgQCAnBuXMdwCBBkbnikXMY2Zc2Vd5gtbvA7nD+F4wIzoAcV7uA45w4BEIShDgzZPtYNxvuuH5YNuhAVk045QBczbAAAXs8wDuKgETdi0+DPABETIV+hBFiYIwAHTxqUVE6D+f4AeUsE2C8qDokRn6sbRpiMe6JQsd+e68ZxZYcIoij8SRx4gIQABCzbqfx4k0YYdFQCJrJidoEn7tJHbts+S4SHYjjOJobgeDkX6UUZ2nFgxQkjIZKG4POEj2Z4UjVHAfz4PRfYvPR0BYdEeG+IRrQAETIAlPT0TxfGtPQbD0D0Yj+fAJBBSFMCRQq0aldFuH4fFAAMqXpagrR1fRRx5YR8AGBAai6KeMCbEVX6lVGhgVdhsUER4TWpa1+W2F1PU3gAcl+hgAMKhOs8gAFb2H8Bj9TUxVDZOo0xdVk3NQ1U0tQYfntXAqBGOQUDLfghgDaFE7lVFY3nY1zWyRp13KbgalyWg12tUAA) showing the type resolution: 

**Example usage:**

```ts
export interface FirestoreTask {
  target: string;
  from: string;
  direction: "inbound" | "outbound";
}

interface FirestoreSchema {
  organizations: {
    tasks: FirestoreReducer.Entity<FirestoreTask>;
  };
}

// rootReducer.ts
combineReducers({
    firestore: firestoreReducer as Reducer<
      FirestoreReducer.Reducer<FirestoreSchema>
    >,
   ... rest
  });
export type RootState = ReturnType<typeof rootReducer>;

// selector.ts
export const selectFirestoreTasks = (state: RootState, key: string) =>
  Object.values(state.firestore.data.organizations?.[key]?.tasks || {});
```

**Questions:**
Should this work even be done on this repo? It seems like there is some duplication between this repo and [redux-firestore](https://github.com/prescottprue/redux-firestore).


Todo:
- [ ] Create a `createTypedFirestoreReducer` to make this easier. 
- [ ] Update the redux-firestore package as well?
- [ ] Update docs with new examples


### Check List
If not relevant to pull request, check off as complete

- [x] All tests passing
- [ ] Docs updated with any changes or examples if applicable
- [x] Added tests to ensure new feature(s) work properly

### Relevant Issues
<!-- * #1 -->
