### PR TITLE
fix(types): add populates to QueryParamOption type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { FirebaseNamespace } from "@firebase/app-types";
+import { FirebaseNamespace } from '@firebase/app-types'
 import * as FirestoreTypes from '@firebase/firestore-types'
 import * as DatabaseTypes from '@firebase/database-types'
 import * as StorageTypes from '@firebase/storage-types'
@@ -343,11 +343,15 @@ interface BaseExtendedFirebaseInstance
  * OptionalOverride is left here in the event that any of the optional properties below need to be extended in the future.
  * Example: OptionalOverride<FirebaseNamespace, 'messaging', { messaging: ExtendedMessagingInstance }>
  */
-type OptionalOverride<T, b extends string, P> = b extends keyof T ? P : {};
+type OptionalOverride<T, b extends string, P> = b extends keyof T ? P : {}
 type OptionalPick<T, b extends string> = Pick<T, b & keyof T>
 
-type ExtendedFirebaseInstance = BaseExtendedFirebaseInstance & OptionalPick<FirebaseNamespace, 'messaging' | 'performance' | 'functions' | 'analytics' | 'remoteConfig'>
-  
+type ExtendedFirebaseInstance = BaseExtendedFirebaseInstance &
+  OptionalPick<
+    FirebaseNamespace,
+    'messaging' | 'performance' | 'functions' | 'analytics' | 'remoteConfig'
+  >
+
 /**
  * Create an extended firebase instance that has methods attached
  * which dispatch redux actions.
@@ -360,8 +364,7 @@ export function createFirebaseInstance(
   firebase: any,
   configs: Partial<ReduxFirestoreConfig>,
   dispatch: Dispatch
-): ExtendedFirebaseInstance;
-
+): ExtendedFirebaseInstance
 
 export type QueryParamOption =
   | 'orderByKey'
@@ -1234,12 +1237,14 @@ export namespace FirebaseReducer {
       expirationTime: number
       refreshToken: string
     }
+    uid: string
   }
 
   // can be extended for optional properties from your database
   export type Profile<ProfileType> = {
     isLoaded: boolean
     isEmpty: boolean
+    uid: string
   } & ProfileType
 
   export namespace firebaseStateReducer {

--- a/index.d.ts
+++ b/index.d.ts
@@ -448,6 +448,8 @@ export interface ReduxFirestoreQuerySetting {
   where?: WhereOptions | WhereOptions[]
   // https://github.com/prescottprue/redux-firestore#orderby
   orderBy?: OrderByOptions | OrderByOptions[]
+  // https://github.com/prescottprue/redux-firestore#population
+  populates?: { child: string; root: string }[]
   // https://github.com/prescottprue/redux-firestore#limit
   limit?: number
   // https://github.com/prescottprue/redux-firestore#storeas

--- a/src/actions/auth.js
+++ b/src/actions/auth.js
@@ -63,7 +63,7 @@ function getProfileFromSnap(snap) {
   }
   // Firestore
   if (snap && snap.data && snap.exists) {
-    return snap.data()
+    return { ...snap.data(), uid: snap.id }
   }
   return null
 }

--- a/test/unit/actions/auth.spec.js
+++ b/test/unit/actions/auth.spec.js
@@ -124,7 +124,7 @@ describe('Actions: Auth -', () => {
         handleProfileWatchResponse(dispatchSpy, firebase, firestoreProfileSnap)
         expect(dispatchSpy).to.be.calledWith({
           type: actionTypes.SET_PROFILE,
-          profile
+          profile: { ...profile, uid: undefined }
         })
       })
 


### PR DESCRIPTION
### Description
This is my first public Pull Request. Please let me know if I'm doing things right!

There were some types missing for Typescript : uid for Auth, and populates for firestore queries. I also wanted to add the uid to the user profile, as I find myself importing the AuthState only for the uid. Since the doc id for the user profile has to be the auth uid, I thought it would be relevant to add it to the user profile.

I am not sure if the docs should be updated for that.

Appreciate any feedback!

### Check List
If not relevant to pull request, check off as complete

- [x] All tests passing 
- [ ] Docs updated with any changes or examples if applicable
- [x] Added tests to ensure new feature(s) work properly

### Relevant Issues
<!-- * #1 -->
