### PR TITLE
chore(docs): link to Query Options in firestore section

### DIFF
--- a/docs/firestore.md
+++ b/docs/firestore.md
@@ -93,6 +93,8 @@ Firestore queries can be created in the following ways:
 1. [Automatically with HOC](#firestoreConnect) - Using `firestoreConnect` HOC (manages mounting/unmounting)
 1. [Manually](#manual) - Using `get`, or by setting listeners with `setListeners`/`setListener` (requires managing of listeners)
 
+See the [redux-firestore API](https://github.com/prescottprue/redux-firestore#api) for an understanding of [query options](https://github.com/prescottprue/redux-firestore#query-options) such as [`where`](https://github.com/prescottprue/redux-firestore#where), [`orderBy`](https://github.com/prescottprue/redux-firestore#orderby) and [`limit`](https://github.com/prescottprue/redux-firestore#limit).
+
 ### Automatically with Hook {#useFirestoreConnect}
 
 `useFirestoreConnect` is a React hook that manages attaching and detaching listeners for you as the component mounts and unmounts.


### PR DESCRIPTION
Explicitly link to redux-firestore API for query options.  There are links to redux-firestore; this context of when to look at the query options is helpful.

### Description


### Check List
If not relevant to pull request, check off as complete

- [ ] All tests passing
- [ ] Docs updated with any changes or examples if applicable
- [ ] Added tests to ensure new feature(s) work properly

### Relevant Issues
<!-- * #1 -->
