### PR TITLE
fix(types): change updateProfile return type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -734,7 +734,7 @@ interface ExtendedAuthInstance {
    * @see https://react-redux-firebase.com/docs/api/firebaseInstance.html#updateprofile
    * @see https://react-redux-firebase.com/docs/recipes/profile.html#update-profile
    */
-  updateProfile: (profile: Partial<ProfileType>, options?: Object) => void
+  updateProfile: (profile: Partial<ProfileType>, options?: Object) => Promise<void>
 }
 
 /**


### PR DESCRIPTION
### Description
`updateProfile` return `void`, but actual type is `Promise` (closes #975)


### Check List
If not relevant to pull request, check off as complete

- [x] All tests passing
- [X] Docs updated with any changes or examples if applicable
- [X] Added tests to ensure new feature(s) work properly

### Relevant Issues
<!-- * #1 -->
