### PR TITLE
fix(types) move static firestore interface to where it's implemented

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -168,7 +168,7 @@ interface BaseExtendedFirebaseInstance
     ExtendedStorageInstance {
   initializeAuth: VoidFunction
 
-  firestore: () => ExtendedFirestoreInstance
+  firestore: (() => ExtendedFirestoreInstance) & FirestoreStatics
 
   dispatch: Dispatch
 
@@ -479,8 +479,7 @@ export type ReduxFirestoreQueriesFunction = (
  * @see https://github.com/prescottprue/redux-firestore#api
  */
 interface ExtendedFirestoreInstance
-  extends FirestoreTypes.FirebaseFirestore,
-    FirestoreStatics {
+  extends FirestoreTypes.FirebaseFirestore {
   /**
    * Get data from firestore.
    * @see https://github.com/prescottprue/redux-firestore#get


### PR DESCRIPTION
### Description
See the linked issue: This fixes how Typescript describes the static elements of `firestore` as implemented by Firebase.

### Check List
If not relevant to pull request, check off as complete

- [x] All tests passing
- [x] Docs updated with any changes or examples if applicable
- [x] Added tests to ensure new feature(s) work properly

### Relevant Issues
<!-- * #1 -->
#1012

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prescottprue/react-redux-firebase/1013)
<!-- Reviewable:end -->
