### PR TITLE
v3.8.1

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,7 +54,7 @@ jobs:
         run: |
           gitBranch=${GITHUB_REF##*/}
           publishFlag=$(if [ "$GITHUB_REF" != 'refs/heads/master' ]; then eval echo '--tag $gitBranch'; else echo ''; fi;)
-          echo "::set-env name=PACKAGE_VERSION::$(cat package.json | jq -r '.version')"
+          echo "PACKAGE_VERSION=$(cat package.json | jq -r '.version')" >> $GITHUB_ENV
           npm publish $publishFlag
 
       - name: Upload Coverage

--- a/index.d.ts
+++ b/index.d.ts
@@ -189,7 +189,7 @@ interface BaseExtendedFirebaseInstance
   /**
    * Sets data to Firebase along with meta data. Currently,
    * this includes createdAt and createdBy. *Warning* using this function
-   * may have unintented consequences (setting createdAt even if data already
+   * may have unintended consequences (setting createdAt even if data already
    * exists)
    * @param path - Path to location on Firebase which to set
    * @param value - Value to write to Firebase
@@ -389,6 +389,7 @@ export interface ReactReduxFirebaseQuerySetting {
   | 'child_moved'
   queryParams?: QueryParamOptions
   storeAs?: string
+  populates?: any[]
 }
 
 /**
@@ -443,20 +444,39 @@ export interface ReduxFirestoreQuerySetting {
    * @see https://github.com/prescottprue/redux-firestore#where
    */
   where?: WhereOptions | WhereOptions[]
-  // https://github.com/prescottprue/redux-firestore#orderby
-  orderBy?: OrderByOptions | OrderByOptions[]
-  // https://github.com/prescottprue/redux-firestore#limit
-  limit?: number
-  // https://github.com/prescottprue/redux-firestore#storeas
-  storeAs?: string
-  // https://github.com/prescottprue/redux-firestore#startat
-  startAt?: FirestoreTypes.DocumentSnapshot | any | any[]
-  // https://github.com/prescottprue/redux-firestore#startafter
-  startAfter?: FirestoreTypes.DocumentSnapshot | any | any[]
-  // https://github.com/prescottprue/redux-firestore#endat
-  endAt?: FirestoreTypes.DocumentSnapshot | any | any[]
-  // https://github.com/prescottprue/redux-firestore#endbefore
   endBefore?: FirestoreTypes.DocumentSnapshot | any | any[]
+  /**
+   * @see https://github.com/prescottprue/redux-firestore#orderby
+   */
+  orderBy?: OrderByOptions | OrderByOptions[]
+  /**
+   * @see https://github.com/prescottprue/redux-firestore#limit
+   */
+  limit?: number
+  /**
+   * @see https://github.com/prescottprue/redux-firestore#storeas
+   */
+  storeAs?: string
+  /**
+   * @see https://github.com/prescottprue/redux-firestore#startat
+   */
+  startAt?: FirestoreTypes.DocumentSnapshot | any | any[]
+  /**
+   * @see https://github.com/prescottprue/redux-firestore#startafter
+   */
+  startAfter?: FirestoreTypes.DocumentSnapshot | any | any[]
+  /**
+   * @see https://github.com/prescottprue/redux-firestore#endat
+   */
+  endAt?: FirestoreTypes.DocumentSnapshot | any | any[]
+  /**
+   * @see https://github.com/prescottprue/redux-firestore#endbefore
+   */
+  endBefore?: FirestoreTypes.DocumentSnapshot | any | any[]
+  /**
+   * @see https://github.com/prescottprue/redux-firestore#population
+   */
+  populates?: any[]
 }
 
 /**
@@ -467,7 +487,7 @@ export type ReduxFirestoreQueries =
   | (ReduxFirestoreQuerySetting | string)
 
 /**
- * Function that recieves component props and returns
+ * Function that receives component props and returns
  * a list of query configuration objects for redux-firestore
  */
 export type ReduxFirestoreQueriesFunction = (
@@ -737,6 +757,29 @@ interface ExtendedAuthInstance {
    * @see https://react-redux-firebase.com/docs/recipes/profile.html#update-profile
    */
   updateProfile: (profile: Partial<ProfileType>, options?: Object) => Promise<void>
+
+  /**
+   * Logs user into Firebase using external.
+   * @param authData - Auth data from Firebase's getRedirectResult
+   * @returns Resolves with user's profile
+   * @see https://react-redux-firebase.com/docs/recipes/auth.html
+   */
+  handleRedirectResult: (authData: any) => Promise<any>
+
+  /**
+   * Re-authenticate user into Firebase. For examples, visit the
+   * [auth section of the docs](https://react-redux-firebase.com/docs/auth.html) or the
+   * [auth recipes section](https://react-redux-firebase.com/docs/recipes/auth.html).
+   * @param credentials - Credentials for authenticating
+   * @param credentials.provider - External provider (google |
+   * facebook | twitter)
+   * @param credentials.type - Type of external authentication
+   * (popup | redirect) (only used with provider)
+   * @returns Resolves with user's auth data
+   * @see https://react-redux-firebase.com/docs/auth.html#logincredentials
+   * @see https://react-redux-firebase.com/docs/api/firebaseInstance.html#login
+   */
+  reauthenticate: (credentials: any) => Promise<any>
 }
 
 /**
@@ -1089,35 +1132,53 @@ export interface ReduxFirestoreConfig {
 
   helpersNamespace: string | null
 
-  // https://github.com/prescottprue/redux-firestore#loglistenererror
+  /**
+   * @see https://github.com/prescottprue/redux-firestore#loglistenererror
+   */
   logListenerError: boolean
 
-  // https://github.com/prescottprue/redux-firestore#enhancernamespace
+  /**
+   * @see https://github.com/prescottprue/redux-firestore#enhancernamespace
+   */
   enhancerNamespace: string
 
-  // https://github.com/prescottprue/redux-firestore#allowmultiplelisteners
+  /**
+   * @see https://github.com/prescottprue/redux-firestore#allowmultiplelisteners
+   */
   allowMultipleListeners:
   | ((listenerToAttach: any, currentListeners: any) => boolean)
   | boolean
 
-  // https://github.com/prescottprue/redux-firestore#preserveondelete
+  /**
+   * @see https://github.com/prescottprue/redux-firestore#preserveondelete
+   */
   preserveOnDelete: null | object
 
-  // https://github.com/prescottprue/redux-firestore#preserveonlistenererror
+  /**
+   * @see https://github.com/prescottprue/redux-firestore#preserveonlistenererror
+   */
   preserveOnListenerError: null | object
 
-  // https://github.com/prescottprue/redux-firestore#onattemptcollectiondelete
+  /**
+   * @see https://github.com/prescottprue/redux-firestore#onattemptcollectiondelete
+   */
   onAttemptCollectionDelete:
   | null
   | ((queryOption: any, dispatch: any, firebase: any) => void)
 
-  // https://github.com/prescottprue/redux-firestore#mergeordered
+  /**
+   * @see https://github.com/prescottprue/redux-firestore#mergeordered
+   */
   mergeOrdered: boolean
 
-  // https://github.com/prescottprue/redux-firestore#mergeordereddocupdate
+  /**
+   * @see https://github.com/prescottprue/redux-firestore#mergeordereddocupdate
+   */
   mergeOrderedDocUpdate: boolean
 
-  // https://github.com/prescottprue/redux-firestore#mergeorderedcollectionupdates
+  /**
+   * @see https://github.com/prescottprue/redux-firestore#mergeorderedcollectionupdates
+   */
   mergeOrderedCollectionUpdates: boolean
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { FirebaseNamespace } from "@firebase/app-types";
+import { FirebaseNamespace } from '@firebase/app-types'
 import * as FirestoreTypes from '@firebase/firestore-types'
 import * as DatabaseTypes from '@firebase/database-types'
 import * as StorageTypes from '@firebase/storage-types'
@@ -343,7 +343,7 @@ interface BaseExtendedFirebaseInstance
  * OptionalOverride is left here in the event that any of the optional properties below need to be extended in the future.
  * Example: OptionalOverride<FirebaseNamespace, 'messaging', { messaging: ExtendedMessagingInstance }>
  */
-type OptionalOverride<T, b extends string, P> = b extends keyof T ? P : {};
+type OptionalOverride<T, b extends string, P> = b extends keyof T ? P : {}
 type OptionalPick<T, b extends string> = Pick<T, b & keyof T>
 
 type ExtendedFirebaseInstance = BaseExtendedFirebaseInstance & OptionalPick<FirebaseNamespace, 'messaging' | 'performance' | 'functions' | 'analytics' | 'remoteConfig'>
@@ -360,8 +360,7 @@ export function createFirebaseInstance(
   firebase: any,
   configs: Partial<ReduxFirestoreConfig>,
   dispatch: Dispatch
-): ExtendedFirebaseInstance;
-
+): ExtendedFirebaseInstance
 
 export type QueryParamOption =
   | 'orderByKey'
@@ -389,7 +388,7 @@ export interface ReactReduxFirebaseQuerySetting {
   | 'child_moved'
   queryParams?: QueryParamOptions
   storeAs?: string
-  populates?: any[]
+  populates?: { child: string; root: string }[]
 }
 
 /**
@@ -476,7 +475,7 @@ export interface ReduxFirestoreQuerySetting {
   /**
    * @see https://github.com/prescottprue/redux-firestore#population
    */
-  populates?: any[]
+  populates?: { child: string; root: string }[]
 }
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-redux-firebase",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-redux-firebase",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "description": "Redux integration for Firebase. Comes with a Higher Order Components for use with React.",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/src/actions/query.js
+++ b/src/actions/query.js
@@ -218,7 +218,7 @@ export function watchEvents(firebase, dispatch, events) {
  * @param {Array} events - List of events for which to remove watchers
  */
 export function unWatchEvents(firebase, dispatch, events) {
-  events.forEach((event) => unWatchEvent(firebase, dispatch, event))
+  events?.forEach((event) => unWatchEvent(firebase, dispatch, event))
 }
 
 /**


### PR DESCRIPTION
### Description
* fix(query): handle un-mounting with no listeners - #1019
* fix(types): add types for `handleRedirectResult` and re-authenticate methods - #987
* fix(types): add `populates` to query settings types - #1027
* fix(ci): remove usage of set-env from publish workflow (deprecated)

### Check List
If not relevant to pull request, check off as complete

- [X] All tests passing
- [X] Docs updated with any changes or examples if applicable
- [X] Added tests to ensure new feature(s) work properly

### Relevant Issues
* #987
* #1019
* #1027