### PR TITLE
fix(typescript): fix reloadAuth argument type and duplicate of endBefore

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -443,7 +443,6 @@ export interface ReduxFirestoreQuerySetting {
    * @see https://github.com/prescottprue/redux-firestore#where
    */
   where?: WhereOptions | WhereOptions[]
-  endBefore?: FirestoreTypes.DocumentSnapshot | any | any[]
   /**
    * @see https://github.com/prescottprue/redux-firestore#orderby
    */
@@ -713,7 +712,7 @@ interface ExtendedAuthInstance {
    * @param credential - The auth credential
    * @see https://react-redux-firebase.com/docs/api/firebaseInstance.html#reloadauth
    */
-  reloadAuth: (credential?: firebase.auth.AuthCredential | any) => Promise<void>
+  reloadAuth: (credential?: AuthTypes.AuthCredential | any) => Promise<void>
 
   /**
    * Links the user account with the given credentials. Internally
@@ -1117,7 +1116,7 @@ interface ReactReduxFirebaseConfig {
   fileMetadataFactory?: (
     uploadRes: StorageTypes.UploadTaskSnapshot,
     firebase: WithFirebaseProps<ProfileType>['firebase'],
-    metadata: StorageTypes.UploadTaskSnapshot.metadata,
+    metadata: StorageTypes.FullMetadata,
     downloadURL: string
   ) => object
 }


### PR DESCRIPTION
### Description
This PR fixes a couple minor errors in the type declaration for `react-redux-firebase`. They're all very simple fixes and look like minor typos or missed spots when bulk updating types.

Screenshot of the errors fixed:
![Screen Shot 2020-11-30 at 5 11 49 PM](https://user-images.githubusercontent.com/1706244/100684803-e695f980-332f-11eb-9573-0eb0b04ff76e.png)


### Check List
If not relevant to pull request, check off as complete

- [x] All tests passing
- [x] Docs updated with any changes or examples if applicable
- [x] Added tests to ensure new feature(s) work properly

### Relevant Issues
https://github.com/prescottprue/react-redux-firebase/issues/997
