### PR TITLE
fix(auth): unWatchUserProfile error when database is not setup

### DIFF
--- a/src/actions/auth.js
+++ b/src/actions/auth.js
@@ -41,7 +41,7 @@ export function unWatchUserProfile(firebase) {
     if (useFirestoreForProfile && firebase.firestore) {
       // Call profile onSnapshot unsubscribe stored on profileWatch
       firebase._.profileWatch()
-    } else {
+    } else if (firebase.database) {
       firebase
         .database()
         .ref()


### PR DESCRIPTION
### Description
My configuration is  ```userProfile:  null,  enableClaims: true``` (ref: https://github.com/prescottprue/react-redux-firebase/pull/1008) and without setup firebase/database.
It throws "firebase.database is not function" error in firebase.logout.

### Check List
If not relevant to pull request, check off as complete

- [x] All tests passing
- [x] Docs updated with any changes or examples if applicable
- [x] Added tests to ensure new feature(s) work properly

### Relevant Issues
<!-- * #1 -->

