### PR TITLE
fix(auth): unWatchUserProfile error when database is not setup

### DIFF
--- a/src/actions/auth.js
+++ b/src/actions/auth.js
@@ -37,19 +37,20 @@ export function unWatchUserProfile(firebase) {
     authUid,
     config: { userProfile, useFirestoreForProfile }
   } = firebase._
-  if (firebase._.profileWatch) {
-    if (useFirestoreForProfile && firebase.firestore) {
-      // Call profile onSnapshot unsubscribe stored on profileWatch
-      firebase._.profileWatch()
-    } else if (firebase.database && userProfile) {
-      firebase
-        .database()
-        .ref()
-        .child(`${userProfile}/${authUid}`)
-        .off('value', firebase._.profileWatch)
-    }
-    firebase._.profileWatch = null
+  if (!firebase._.profileWatch) {
+    return
   }
+  if (useFirestoreForProfile && firebase.firestore) {
+    // Call profile onSnapshot unsubscribe stored on profileWatch
+    firebase._.profileWatch()
+  } else if (userProfile && firebase.database) {
+    firebase
+      .database()
+      .ref()
+      .child(`${userProfile}/${authUid}`)
+      .off('value', firebase._.profileWatch)
+  }
+  firebase._.profileWatch = null
 }
 
 /**

--- a/src/actions/auth.js
+++ b/src/actions/auth.js
@@ -41,7 +41,7 @@ export function unWatchUserProfile(firebase) {
     if (useFirestoreForProfile && firebase.firestore) {
       // Call profile onSnapshot unsubscribe stored on profileWatch
       firebase._.profileWatch()
-    } else {
+    } else if (firebase.database && userProfile) {
       firebase
         .database()
         .ref()


### PR DESCRIPTION
### Description
My configuration is  ```userProfile:  null,  enableClaims: true``` (ref: #1008) and without setup firebase/database.
It throws "firebase.database is not function" error in firebase.logout.

### Check List
If not relevant to pull request, check off as complete

- [x] All tests passing
- [x] Docs updated with any changes or examples if applicable
- [x] Added tests to ensure new feature(s) work properly

### Relevant Issues
<!-- * #1 -->
