### PR TITLE
v3.9.0

### DIFF
--- a/docs/api/constants.md
+++ b/docs/api/constants.md
@@ -2,13 +2,13 @@
 
 ### Table of Contents
 
--   [actionsPrefix][1]
-    -   [Examples][2]
--   [actionTypes][3]
-    -   [Properties][4]
-    -   [Examples][5]
--   [defaultConfig][6]
-    -   [Properties][7]
+- [actionsPrefix][1]
+  - [Examples][2]
+- [actionTypes][3]
+  - [Properties][4]
+  - [Examples][5]
+- [defaultConfig][6]
+  - [Properties][7]
 
 ## actionsPrefix
 
@@ -31,46 +31,46 @@ Type: [object][9]
 
 ### Properties
 
--   `START` **[string][8]** `@@reactReduxFirebase/START`
--   `SET` **[string][8]** `@@reactReduxFirebase/SET`
--   `REMOVE` **[string][8]** `@@reactReduxFirebase/REMOVE`
--   `MERGE` **[string][8]** `@@reactReduxFirebase/MERGE`
--   `SET_PROFILE` **[string][8]** `@@reactReduxFirebase/SET_PROFILE`
--   `LOGIN` **[string][8]** `@@reactReduxFirebase/LOGIN`
--   `LOGOUT` **[string][8]** `@@reactReduxFirebase/LOGOUT`
--   `LOGIN_ERROR` **[string][8]** `@@reactReduxFirebase/LOGIN_ERROR`
--   `NO_VALUE` **[string][8]** `@@reactReduxFirebase/NO_VALUE`
--   `UNAUTHORIZED_ERROR` **[string][8]** `@@reactReduxFirebase/UNAUTHORIZED_ERROR`
--   `ERROR` **[string][8]** `@@reactReduxFirebase/ERROR`
--   `SET_LISTENER` **[string][8]** `@@reactReduxFirebase/SET_LISTENER`
--   `UNSET_LISTENER` **[string][8]** `@@reactReduxFirebase/UNSET_LISTENER`
--   `AUTHENTICATION_INIT_STARTED` **[string][8]** `@@reactReduxFirebase/AUTHENTICATION_INIT_STARTED`
--   `AUTHENTICATION_INIT_FINISHED` **[string][8]** `@@reactReduxFirebase/AUTHENTICATION_INIT_FINISHED`
--   `SESSION_START` **[string][8]** `@@reactReduxFirebase/SESSION_START`
--   `SESSION_END` **[string][8]** `@@reactReduxFirebase/SESSION_END`
--   `FILE_UPLOAD_START` **[string][8]** `@@reactReduxFirebase/FILE_UPLOAD_START`
--   `FILE_UPLOAD_ERROR` **[string][8]** `@@reactReduxFirebase/FILE_UPLOAD_ERROR`
--   `FILE_UPLOAD_PROGRESS` **[string][8]** `@@reactReduxFirebase/FILE_UPLOAD_PROGRESS`
--   `FILE_UPLOAD_COMPLETE` **[string][8]** `@@reactReduxFirebase/FILE_UPLOAD_COMPLETE`
--   `FILE_DELETE_START` **[string][8]** `@@reactReduxFirebase/FILE_DELETE_START`
--   `FILE_DELETE_ERROR` **[string][8]** `@@reactReduxFirebase/FILE_DELETE_ERROR`
--   `FILE_DELETE_COMPLETE` **[string][8]** `@@reactReduxFirebase/FILE_DELETE_COMPLETE`
--   `AUTH_UPDATE_START` **[string][8]** `@@reactReduxFirebase/AUTH_UPDATE_START`
--   `AUTH_UPDATE_ERROR` **[string][8]** `@@reactReduxFirebase/AUTH_UPDATE_ERROR`
--   `AUTH_UPDATE_SUCCESS` **[string][8]** `@@reactReduxFirebase/AUTH_UPDATE_SUCCESS`
--   `PROFILE_UPDATE_START` **[string][8]** `@@reactReduxFirebase/PROFILE_UPDATE_START`
--   `PROFILE_UPDATE_ERROR` **[string][8]** `@@reactReduxFirebase/PROFILE_UPDATE_ERROR`
--   `PROFILE_UPDATE_SUCCESS` **[string][8]** `@@reactReduxFirebase/PROFILE_UPDATE_SUCCESS`
--   `EMAIL_UPDATE_START` **[string][8]** `@@reactReduxFirebase/EMAIL_UPDATE_START`
--   `EMAIL_UPDATE_ERROR` **[string][8]** `@@reactReduxFirebase/EMAIL_UPDATE_ERROR`
--   `EMAIL_UPDATE_SUCCESS` **[string][8]** `@@reactReduxFirebase/EMAIL_UPDATE_SUCCESS`
--   `AUTH_RELOAD_START` **[string][8]** `@@reactReduxFirebase/AUTH_RELOAD_START`
--   `AUTH_RELOAD_ERROR` **[string][8]** `@@reactReduxFirebase/AUTH_RELOAD_ERROR`
--   `AUTH_RELOAD_SUCCESS` **[string][8]** `@@reactReduxFirebase/AUTH_RELOAD_SUCCESS`
--   `AUTH_LINK_START` **[string][8]** `@@reactReduxFirebase/AUTH_LINK_START`
--   `AUTH_LINK_ERROR` **[string][8]** `@@reactReduxFirebase/AUTH_LINK_ERROR`
--   `AUTH_LINK_SUCCESS` **[string][8]** `@@reactReduxFirebase/AUTH_LINK_SUCCESS`
--   `AUTH_EMPTY_CHANGE` **[string][8]** `@@reactReduxFirebase/AUTH_LINK_SUCCESS`
+- `START` **[string][8]** `@@reactReduxFirebase/START`
+- `SET` **[string][8]** `@@reactReduxFirebase/SET`
+- `REMOVE` **[string][8]** `@@reactReduxFirebase/REMOVE`
+- `MERGE` **[string][8]** `@@reactReduxFirebase/MERGE`
+- `SET_PROFILE` **[string][8]** `@@reactReduxFirebase/SET_PROFILE`
+- `LOGIN` **[string][8]** `@@reactReduxFirebase/LOGIN`
+- `LOGOUT` **[string][8]** `@@reactReduxFirebase/LOGOUT`
+- `LOGIN_ERROR` **[string][8]** `@@reactReduxFirebase/LOGIN_ERROR`
+- `NO_VALUE` **[string][8]** `@@reactReduxFirebase/NO_VALUE`
+- `UNAUTHORIZED_ERROR` **[string][8]** `@@reactReduxFirebase/UNAUTHORIZED_ERROR`
+- `ERROR` **[string][8]** `@@reactReduxFirebase/ERROR`
+- `SET_LISTENER` **[string][8]** `@@reactReduxFirebase/SET_LISTENER`
+- `UNSET_LISTENER` **[string][8]** `@@reactReduxFirebase/UNSET_LISTENER`
+- `AUTHENTICATION_INIT_STARTED` **[string][8]** `@@reactReduxFirebase/AUTHENTICATION_INIT_STARTED`
+- `AUTHENTICATION_INIT_FINISHED` **[string][8]** `@@reactReduxFirebase/AUTHENTICATION_INIT_FINISHED`
+- `SESSION_START` **[string][8]** `@@reactReduxFirebase/SESSION_START`
+- `SESSION_END` **[string][8]** `@@reactReduxFirebase/SESSION_END`
+- `FILE_UPLOAD_START` **[string][8]** `@@reactReduxFirebase/FILE_UPLOAD_START`
+- `FILE_UPLOAD_ERROR` **[string][8]** `@@reactReduxFirebase/FILE_UPLOAD_ERROR`
+- `FILE_UPLOAD_PROGRESS` **[string][8]** `@@reactReduxFirebase/FILE_UPLOAD_PROGRESS`
+- `FILE_UPLOAD_COMPLETE` **[string][8]** `@@reactReduxFirebase/FILE_UPLOAD_COMPLETE`
+- `FILE_DELETE_START` **[string][8]** `@@reactReduxFirebase/FILE_DELETE_START`
+- `FILE_DELETE_ERROR` **[string][8]** `@@reactReduxFirebase/FILE_DELETE_ERROR`
+- `FILE_DELETE_COMPLETE` **[string][8]** `@@reactReduxFirebase/FILE_DELETE_COMPLETE`
+- `AUTH_UPDATE_START` **[string][8]** `@@reactReduxFirebase/AUTH_UPDATE_START`
+- `AUTH_UPDATE_ERROR` **[string][8]** `@@reactReduxFirebase/AUTH_UPDATE_ERROR`
+- `AUTH_UPDATE_SUCCESS` **[string][8]** `@@reactReduxFirebase/AUTH_UPDATE_SUCCESS`
+- `PROFILE_UPDATE_START` **[string][8]** `@@reactReduxFirebase/PROFILE_UPDATE_START`
+- `PROFILE_UPDATE_ERROR` **[string][8]** `@@reactReduxFirebase/PROFILE_UPDATE_ERROR`
+- `PROFILE_UPDATE_SUCCESS` **[string][8]** `@@reactReduxFirebase/PROFILE_UPDATE_SUCCESS`
+- `EMAIL_UPDATE_START` **[string][8]** `@@reactReduxFirebase/EMAIL_UPDATE_START`
+- `EMAIL_UPDATE_ERROR` **[string][8]** `@@reactReduxFirebase/EMAIL_UPDATE_ERROR`
+- `EMAIL_UPDATE_SUCCESS` **[string][8]** `@@reactReduxFirebase/EMAIL_UPDATE_SUCCESS`
+- `AUTH_RELOAD_START` **[string][8]** `@@reactReduxFirebase/AUTH_RELOAD_START`
+- `AUTH_RELOAD_ERROR` **[string][8]** `@@reactReduxFirebase/AUTH_RELOAD_ERROR`
+- `AUTH_RELOAD_SUCCESS` **[string][8]** `@@reactReduxFirebase/AUTH_RELOAD_SUCCESS`
+- `AUTH_LINK_START` **[string][8]** `@@reactReduxFirebase/AUTH_LINK_START`
+- `AUTH_LINK_ERROR` **[string][8]** `@@reactReduxFirebase/AUTH_LINK_ERROR`
+- `AUTH_LINK_SUCCESS` **[string][8]** `@@reactReduxFirebase/AUTH_LINK_SUCCESS`
+- `AUTH_EMPTY_CHANGE` **[string][8]** `@@reactReduxFirebase/AUTH_LINK_SUCCESS`
 
 ### Examples
 
@@ -87,110 +87,95 @@ Type: [object][9]
 
 ### Properties
 
--   `userProfile` **[string][8]** `null` Location on Firebase where user
-    profiles are stored. Often set to `'users'`.
--   `profileFactory` **[Function][10]** `null` Function for changing how profile is written
-    to database (both RTDB and Firestore).
--   `presence` **([string][8] \| [Function][10])** `null` Location on Firebase where of currently
-    online users is stored. Often set to `'presence'` or `'onlineUsers'`. If a function
-    is passed, the arguments are: `(currentUser, firebase)`.
--   `sessions` **([string][8] \| [Function][10])** `sessions` Location on Firebase where user
-    sessions are stored (only if presense is set). Often set to `'sessions'` or
-    `'userSessions'`. If a function is passed, the arguments are: `(currentUser, firebase)`.
--   `enableLogging` **[boolean][11]** `false` Whether or not firebase
-    database logging is enabled. Providing `true` turns on error logging
-    (enabled by itself through `logErrors`).
--   `logErrors` **[boolean][11]** `true` Whether or not to log internal
-    Firebase errors (i.e. error querying or writing data) to the javascript
-    console .
--   `preserveOnLogout` **([Array][12] \| [object][9])** `null` Data parameters to
-    preserve when logging out. If Array is passed, each item represents keys
-    within state.firebase.data preserve. If an object is passed, Keys associate
-    with parts of state to preserve, and the values are Arrays contain keys
-    for keys within that slice of state to preserve.
--   `preserveOnEmptyAuthChange` **[object][9]** `null` Data parameters to
-    preserve when empty auth changes occur. Keys associate with parts of state
-    to preserve, and the values are either Arrays or Functions. If passing an
-    array of keys (i.e. `{ auth: ['key1', 'key2'] }`) - those keys (`'key1'` and
-    `'key2'`) are preserved from that slice of state (`auth`). If passing a
-    function (i.e. `{ auth: (currentAuthState, nextAuthState) => ({}) }`),
-    whatever is returned from the function is set to that slice of state (`auth`).
--   `updateProfileOnLogin` **[boolean][11]** `true` Whether or not to update
-    user profile when logging in.
--   `useFirestoreForProfile` **[boolean][11]** `false` Write profile
-    data to Firestore instead of Real Time Database.
--   `useFirestoreForStorageMeta` **[boolean][11]** `false` Write storage
-    file metadata to Firestore instead of Real Time Database.
--   `resetBeforeLogin` **[boolean][11]** `true` Whether or not to reset auth
-    and profile when logging in (see issue
-    [#254][13]
-    for more details).
--   `enableRedirectHandling` **[boolean][11]** `true` Whether or not to enable
-    redirect handling. This must be disabled if environment is not http/https
-    such as with react-native.
--   `onAuthStateChanged` **[Function][10]** `null` Function that runs when
-    auth state changes.
--   `enableEmptyAuthChanges` **[boolean][11]** `false` Whether or not to enable
-    empty auth changes. When set to true, `onAuthStateChanged` will be fired with,
-    empty auth changes such as `undefined` on initialization
-    (see [#137][14]).
-    Requires `v1.5.0-alpha` or higher.
--   `autoPopulateProfile` **[boolean][11]** `false` REMOVED FROM v2.0.0.
-    Whether or not to automatically populate profile with data loaded through
-    profileParamsToPopulate config.
--   `setProfilePopulateResults` **[boolean][11]** `true` Whether or not to
-    call SET actions for data that results from populating profile to redux under
-    the data path. For example role parameter on profile populated from 'roles'
-    root. True will call SET_PROFILE as well as a SET action with the role that
-    is loaded (places it in data/roles).
--   `dispatchOnUnsetListener` **[boolean][11]** `true` Whether or not to
-    dispatch UNSET_LISTENER when disabling listeners for a specific path. USE WITH CAUTION
-    Setting this to true allows an action to be called that removes data
-    from redux (which might not always be expected).
--   `dispatchRemoveAction` **[boolean][11]** `false` Whether or not to
-    dispatch REMOVE action when calling `remove`. **NOTE** Causes two state
-    updates if a listener is affected by your remove call.
--   `firebaseStateName` **[string][8]** 'firebase' Assumed name of Firebase
-    state (name given when passing reducer to combineReducers). Used in
-    firebaseAuthIsReady promise (see
-    [#264][15]).
--   `attachAuthIsReady` **[boolean][11]** `true` Whether or not to attach
-    firebaseAuthIsReady to store. authIsLoaded can be imported and used
-    directly instead based on preference.
--   `firestoreNamespace` **[boolean][11]** `firestoreHelpers` Namespace for
-    firestore helpers (**WARNING** Changing this will break firestoreConnect HOC.
-    Do **NOT** change to `'firestore'`)
--   `keysToRemoveFromAuth` **[Array][12]** (default at end)
-    list of keys to remove from authentication reponse before writing to profile
-    (currenlty only used for profiles stored on Firestore). `['appName', 'apiKey'
-    , 'authDomain', 'redirectEventId', 'stsTokenManager', 'uid']`
+- `userProfile` **[string][8]** `null` Location on Firebase where user
+  profiles are stored. Often set to `'users'`.
+- `profileFactory` **[Function][10]** `null` Function for changing how profile is written
+  to database (both RTDB and Firestore).
+- `presence` **([string][8] \| [Function][10])** `null` Location on Firebase where of currently
+  online users is stored. Often set to `'presence'` or `'onlineUsers'`. If a function
+  is passed, the arguments are: `(currentUser, firebase)`.
+- `sessions` **([string][8] \| [Function][10])** `sessions` Location on Firebase where user
+  sessions are stored (only if presense is set). Often set to `'sessions'` or
+  `'userSessions'`. If a function is passed, the arguments are: `(currentUser, firebase)`.
+- `enableLogging` **[boolean][11]** `false` (_deprecated_) Whether or not firebase
+  database logging is enabled. Providing `true` turns on error logging
+  (enabled by itself through `logErrors`).
+- `logErrors` **[boolean][11]** `true` Whether or not to log internal
+  Firebase errors (i.e. error querying or writing data) to the javascript
+  console .
+- `preserveOnLogout` **([Array][12] \| [object][9])** `null` Data parameters to
+  preserve when logging out. If Array is passed, each item represents keys
+  within state.firebase.data preserve. If an object is passed, Keys associate
+  with parts of state to preserve, and the values are Arrays contain keys
+  for keys within that slice of state to preserve.
+- `preserveOnEmptyAuthChange` **[object][9]** `null` Data parameters to
+  preserve when empty auth changes occur. Keys associate with parts of state
+  to preserve, and the values are either Arrays or Functions. If passing an
+  array of keys (i.e. `{ auth: ['key1', 'key2'] }`) - those keys (`'key1'` and
+  `'key2'`) are preserved from that slice of state (`auth`). If passing a
+  function (i.e. `{ auth: (currentAuthState, nextAuthState) => ({}) }`),
+  whatever is returned from the function is set to that slice of state (`auth`).
+- `updateProfileOnLogin` **[boolean][11]** `true` Whether or not to update
+  user profile when logging in.
+- `useFirestoreForProfile` **[boolean][11]** `false` Write profile
+  data to Firestore instead of Real Time Database.
+- `useFirestoreForStorageMeta` **[boolean][11]** `false` Write storage
+  file metadata to Firestore instead of Real Time Database.
+- `resetBeforeLogin` **[boolean][11]** `true` Whether or not to reset auth
+  and profile when logging in (see issue
+  [#254][13]
+  for more details).
+- `enableRedirectHandling` **[boolean][11]** `true` Whether or not to enable
+  redirect handling. This must be disabled if environment is not http/https
+  such as with react-native.
+- `onAuthStateChanged` **[Function][10]** `null` Function that runs when
+  auth state changes.
+- `enableEmptyAuthChanges` **[boolean][11]** `false` Whether or not to enable
+  empty auth changes. When set to true, `onAuthStateChanged` will be fired with,
+  empty auth changes such as `undefined` on initialization
+  (see [#137][14]).
+  Requires `v1.5.0-alpha` or higher.
+- `autoPopulateProfile` **[boolean][11]** `false` REMOVED FROM v2.0.0.
+  Whether or not to automatically populate profile with data loaded through
+  profileParamsToPopulate config.
+- `setProfilePopulateResults` **[boolean][11]** `true` Whether or not to
+  call SET actions for data that results from populating profile to redux under
+  the data path. For example role parameter on profile populated from 'roles'
+  root. True will call SET_PROFILE as well as a SET action with the role that
+  is loaded (places it in data/roles).
+- `dispatchOnUnsetListener` **[boolean][11]** `true` Whether or not to
+  dispatch UNSET_LISTENER when disabling listeners for a specific path. USE WITH CAUTION
+  Setting this to true allows an action to be called that removes data
+  from redux (which might not always be expected).
+- `dispatchRemoveAction` **[boolean][11]** `false` Whether or not to
+  dispatch REMOVE action when calling `remove`. **NOTE** Causes two state
+  updates if a listener is affected by your remove call.
+- `firebaseStateName` **[string][8]** 'firebase' Assumed name of Firebase
+  state (name given when passing reducer to combineReducers). Used in
+  firebaseAuthIsReady promise (see
+  [#264][15]).
+- `attachAuthIsReady` **[boolean][11]** `true` Whether or not to attach
+  firebaseAuthIsReady to store. authIsLoaded can be imported and used
+  directly instead based on preference.
+- `firestoreNamespace` **[boolean][11]** `firestoreHelpers` Namespace for
+  firestore helpers (**WARNING** Changing this will break firestoreConnect HOC.
+  Do **NOT** change to `'firestore'`)
+- `keysToRemoveFromAuth` **[Array][12]** (default at end)
+  list of keys to remove from authentication reponse before writing to profile
+  (currenlty only used for profiles stored on Firestore). `['appName', 'apiKey' , 'authDomain', 'redirectEventId', 'stsTokenManager', 'uid']`
 
 [1]: #actionsprefix
-
 [2]: #examples
-
 [3]: #actiontypes
-
 [4]: #properties
-
 [5]: #examples-1
-
 [6]: #defaultconfig
-
 [7]: #properties-1
-
 [8]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
-
 [9]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object
-
 [10]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function
-
 [11]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean
-
 [12]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array
-
 [13]: https://github.com/prescottprue/react-redux-firebase/issues/254
-
 [14]: https://github.com/prescottprue/react-redux-firebase/issues/137
-
 [15]: https://github.com/prescottprue/react-redux-firebase/issues/264

--- a/docs/api/firebaseInstance.md
+++ b/docs/api/firebaseInstance.md
@@ -2,73 +2,75 @@
 
 ### Table of Contents
 
--   [createFirebaseInstance][1]
-    -   [Parameters][2]
--   [set][3]
-    -   [Parameters][4]
--   [setWithMeta][5]
-    -   [Parameters][6]
--   [push][7]
-    -   [Parameters][8]
-    -   [Examples][9]
--   [pushWithMeta][10]
-    -   [Parameters][11]
--   [update][12]
-    -   [Parameters][13]
-    -   [Examples][14]
--   [updateWithMeta][15]
-    -   [Parameters][16]
--   [remove][17]
-    -   [Parameters][18]
-    -   [Examples][19]
--   [uniqueSet][20]
-    -   [Parameters][21]
-    -   [Examples][22]
--   [uploadFile][23]
-    -   [Parameters][24]
--   [uploadFiles][25]
-    -   [Parameters][26]
--   [deleteFile][27]
-    -   [Parameters][28]
--   [watchEvent][29]
-    -   [Parameters][30]
--   [unWatchEvent][31]
-    -   [Parameters][32]
--   [promiseEvents][33]
-    -   [Parameters][34]
--   [login][35]
-    -   [Parameters][36]
--   [reauthenticate][37]
-    -   [Parameters][38]
--   [handleRedirectResult][39]
-    -   [Parameters][40]
--   [logout][41]
--   [createUser][42]
-    -   [Parameters][43]
--   [resetPassword][44]
-    -   [Parameters][45]
--   [confirmPasswordReset][46]
-    -   [Parameters][47]
--   [verifyPasswordResetCode][48]
-    -   [Parameters][49]
--   [updateProfile][50]
-    -   [Parameters][51]
--   [updateAuth][52]
-    -   [Parameters][53]
--   [updateEmail][54]
-    -   [Parameters][55]
--   [reloadAuth][56]
--   [linkWithCredential][57]
-    -   [Parameters][58]
--   [actionCreators][59]
-    -   [Parameters][60]
--   [actionCreators][61]
--   [ref][62]
--   [database][63]
--   [storage][64]
--   [auth][65]
--   [getFirebase][66]
-    -   [Examples][67]
+- [createFirebaseInstance][1]
+  - [Parameters][2]
+- [set][3]
+  - [Parameters][4]
+- [setWithMeta][5]
+  - [Parameters][6]
+- [push][7]
+  - [Parameters][8]
+  - [Examples][9]
+- [pushWithMeta][10]
+  - [Parameters][11]
+- [update][12]
+  - [Parameters][13]
+  - [Examples][14]
+- [updateWithMeta][15]
+  - [Parameters][16]
+- [remove][17]
+  - [Parameters][18]
+  - [Examples][19]
+- [uniqueSet][20]
+  - [Parameters][21]
+  - [Examples][22]
+- [uploadFile][23]
+  - [Parameters][24]
+- [uploadFiles][25]
+  - [Parameters][26]
+- [deleteFile][27]
+  - [Parameters][28]
+- [watchEvent][29]
+  - [Parameters][30]
+- [unWatchEvent][31]
+  - [Parameters][32]
+- [promiseEvents][33]
+  - [Parameters][34]
+- [login][35]
+  - [Parameters][36]
+- [reauthenticate][37]
+  - [Parameters][38]
+- [handleRedirectResult][39]
+  - [Parameters][40]
+- [logout][41]
+- [createUser][42]
+  - [Parameters][43]
+- [resetPassword][44]
+  - [Parameters][45]
+- [confirmPasswordReset][46]
+  - [Parameters][47]
+- [verifyPasswordResetCode][48]
+  - [Parameters][49]
+- [applyActionCode][50]
+  - [Parameters][51]
+- [updateProfile][52]
+  - [Parameters][53]
+- [updateAuth][54]
+  - [Parameters][55]
+- [updateEmail][56]
+  - [Parameters][57]
+- [reloadAuth][58]
+- [linkWithCredential][59]
+  - [Parameters][60]
+- [actionCreators][61]
+  - [Parameters][62]
+- [actionCreators][63]
+- [ref][64]
+- [database][65]
+- [storage][66]
+- [auth][67]
+- [getFirebase][68]
+  - [Examples][69]
 
 ## createFirebaseInstance
 
@@ -77,11 +79,11 @@ which dispatch redux actions.
 
 ### Parameters
 
--   `firebase` **[object][68]** Firebase instance which to extend
--   `configs` **[object][68]** Configuration object
--   `dispatch` **[Function][69]** Action dispatch function
+- `firebase` **[object][70]** Firebase instance which to extend
+- `configs` **[object][70]** Configuration object
+- `dispatch` **[Function][71]** Action dispatch function
 
-Returns **[object][68]** Extended Firebase instance
+Returns **[object][70]** Extended Firebase instance
 
 ## set
 
@@ -101,14 +103,13 @@ Sets data to Firebase.
 
 ### Parameters
 
--   `path` **[string][71]** Path to location on Firebase which to set
--   `value` **([object][68] \| [string][71] \| [boolean][72] \| [number][73])** Value to write to Firebase
--   `onComplete` **[Function][69]** Function to run on complete (`not required`)
+- `path` **[string][73]** Path to location on Firebase which to set
+- `value` **([object][70] \| [string][73] \| [boolean][74] \| [number][75])** Value to write to Firebase
+- `onComplete` **[Function][71]** Function to run on complete (`not required`)
 
-Returns **[Promise][74]** Containing reference snapshot
+Returns **[Promise][76]** Containing reference snapshot
 
 ## setWithMeta
-
 
 Sets data to Firebase along with meta data. Currently,
 this includes createdAt and createdBy. _Warning_ using this function
@@ -117,22 +118,21 @@ exists).
 
 ### Parameters
 
--   `path` **[string][71]** Path to location on Firebase which to set
--   `value` **([object][68] \| [string][71] \| [boolean][72] \| [number][73])** Value to write to Firebase
--   `onComplete` **[Function][69]** Function to run on complete (`not required`)
+- `path` **[string][73]** Path to location on Firebase which to set
+- `value` **([object][70] \| [string][73] \| [boolean][74] \| [number][75])** Value to write to Firebase
+- `onComplete` **[Function][71]** Function to run on complete (`not required`)
 
-Returns **[Promise][74]** Containing reference snapshot
+Returns **[Promise][76]** Containing reference snapshot
 
 ## push
-
 
 Pushes data to Firebase.
 
 ### Parameters
 
--   `path` **[string][71]** Path to location on Firebase which to push
--   `value` **([object][68] \| [string][71] \| [boolean][72] \| [number][73])** Value to push to Firebase
--   `onComplete` **[Function][69]** Function to run on complete (`not required`)
+- `path` **[string][73]** Path to location on Firebase which to push
+- `value` **([object][70] \| [string][73] \| [boolean][74] \| [number][75])** Value to push to Firebase
+- `onComplete` **[Function][71]** Function to run on complete (`not required`)
 
 ### Examples
 
@@ -145,40 +145,37 @@ import { firebaseConnect } from 'react-redux-firebase'
 
 function Example({ firebase: { push } }) {
   return (
-    <button onClick={() => push('some/path', true)}>
-      Push To Firebase
-    </button>
+    <button onClick={() => push('some/path', true)}>Push To Firebase</button>
   )
 }
 export default firebaseConnect()(Example)
 ```
 
-Returns **[Promise][74]** Containing reference snapshot
+Returns **[Promise][76]** Containing reference snapshot
 
 ## pushWithMeta
-
 
 Pushes data to Firebase along with meta data. Currently,
 this includes createdAt and createdBy.
 
 ### Parameters
 
--   `path` **[string][71]** Path to location on Firebase which to set
--   `value` **([object][68] \| [string][71] \| [boolean][72] \| [number][73])** Value to write to Firebase
--   `onComplete` **[Function][69]** Function to run on complete (`not required`)
+- `path` **[string][73]** Path to location on Firebase which to set
+- `value` **([object][70] \| [string][73] \| [boolean][74] \| [number][75])** Value to write to Firebase
+- `onComplete` **[Function][71]** Function to run on complete (`not required`)
 
-Returns **[Promise][74]** Containing reference snapshot
+Returns **[Promise][76]** Containing reference snapshot
 
 ## update
 
 Updates data on Firebase and sends new data. More info
-available in [the docs][75].
+available in [the docs][77].
 
 ### Parameters
 
--   `path` **[string][71]** Path to location on Firebase which to update
--   `value` **([object][68] \| [string][71] \| [boolean][72] \| [number][73])** Value to update to Firebase
--   `onComplete` **[Function][69]** Function to run on complete (`not required`)
+- `path` **[string][73]** Path to location on Firebase which to update
+- `value` **([object][70] \| [string][73] \| [boolean][74] \| [number][75])** Value to update to Firebase
+- `onComplete` **[Function][71]** Function to run on complete (`not required`)
 
 ### Examples
 
@@ -203,10 +200,9 @@ function Example({ firebase: { update } }) {
 export default firebaseConnect()(Example)
 ```
 
-Returns **[Promise][74]** Containing reference snapshot
+Returns **[Promise][76]** Containing reference snapshot
 
 ## updateWithMeta
-
 
 Updates data on Firebase along with meta. _Warning_
 using this function may have unintented consequences (setting
@@ -214,14 +210,13 @@ createdAt even if data already exists).
 
 ### Parameters
 
--   `path` **[string][71]** Path to location on Firebase which to update
--   `value` **([object][68] \| [string][71] \| [boolean][72] \| [number][73])** Value to update to Firebase
--   `onComplete` **[Function][69]** Function to run on complete (`not required`)
+- `path` **[string][73]** Path to location on Firebase which to update
+- `value` **([object][70] \| [string][73] \| [boolean][74] \| [number][75])** Value to update to Firebase
+- `onComplete` **[Function][71]** Function to run on complete (`not required`)
 
-Returns **[Promise][74]** Containing reference snapshot
+Returns **[Promise][76]** Containing reference snapshot
 
 ## remove
-
 
 Removes data from Firebase at a given path. **NOTE** A
 seperate action is not dispatched unless `dispatchRemoveAction: true` is
@@ -230,9 +225,9 @@ be attached in order for state to be updated when calling remove.
 
 ### Parameters
 
--   `path` **[string][71]** Path to location on Firebase which to remove
--   `onComplete` **[Function][69]** Function to run on complete (`not required`)
--   `options` **[Function][69]** Options object
+- `path` **[string][73]** Path to location on Firebase which to remove
+- `onComplete` **[Function][71]** Function to run on complete (`not required`)
+- `options` **[Function][71]** Options object
 
 ### Examples
 
@@ -245,18 +240,15 @@ import { firebaseConnect } from 'react-redux-firebase'
 
 function Example({ firebase: { remove } }) {
   return (
-    <button onClick={() => remove('some/path')}>
-      Remove From Firebase
-    </button>
+    <button onClick={() => remove('some/path')}>Remove From Firebase</button>
   )
 }
 export default firebaseConnect()(Example)
 ```
 
-Returns **[Promise][74]** Containing reference snapshot
+Returns **[Promise][76]** Containing reference snapshot
 
 ## uniqueSet
-
 
 Sets data to Firebase only if the path does not already
 exist, otherwise it rejects. Internally uses a Firebase transaction to
@@ -264,9 +256,9 @@ prevent a race condition between seperate clients calling uniqueSet.
 
 ### Parameters
 
--   `path` **[string][71]** Path to location on Firebase which to set
--   `value` **([object][68] \| [string][71] \| [boolean][72] \| [number][73])** Value to write to Firebase
--   `onComplete` **[Function][69]** Function to run on complete (`not required`)
+- `path` **[string][73]** Path to location on Firebase which to set
+- `value` **([object][70] \| [string][73] \| [boolean][74] \| [number][75])** Value to write to Firebase
+- `onComplete` **[Function][71]** Function to run on complete (`not required`)
 
 ### Examples
 
@@ -287,77 +279,72 @@ function Example({ firebase: { uniqueSet } }) {
 export default firebaseConnect()(Example)
 ```
 
-Returns **[Promise][74]** Containing reference snapshot
+Returns **[Promise][76]** Containing reference snapshot
 
 ## uploadFile
 
-
 Upload a file to Firebase Storage with the option to store
 its metadata in Firebase Database. More info available
-in [the docs][82].
+in [the docs][84].
 
 ### Parameters
 
--   `path` **[string][71]** Path to location on Firebase which to set
--   `file` **File** File object to upload (usually first element from
-    array output of select-file or a drag/drop `onDrop`)
--   `dbPath` **[string][71]** Database path to place uploaded file metadata
--   `options` **[object][68]** Options
-    -   `options.name` **[string][71]** Name of the file
-    -   `options.metdata` **[object][68]** Metadata for the file (passed as second
-        argument to storage.put calls)
+- `path` **[string][73]** Path to location on Firebase which to set
+- `file` **File** File object to upload (usually first element from
+  array output of select-file or a drag/drop `onDrop`)
+- `dbPath` **[string][73]** Database path to place uploaded file metadata
+- `options` **[object][70]** Options
+  - `options.name` **[string][73]** Name of the file
+  - `options.metdata` **[object][70]** Metadata for the file (passed as second
+    argument to storage.put calls)
 
-Returns **[Promise][74]** Containing the File object
+Returns **[Promise][76]** Containing the File object
 
 ## uploadFiles
-
 
 Upload multiple files to Firebase Storage with the option
 to store their metadata in Firebase Database.
 
 ### Parameters
 
--   `path` **[string][71]** Path to location on Firebase which to set
--   `files` **[Array][84]** Array of File objects to upload (usually from
-    a select-file or a drag/drop `onDrop`)
--   `dbPath` **[string][71]** Database path to place uploaded files metadata.
--   `options` **[object][68]** Options
-    -   `options.name` **[string][71]** Name of the file
+- `path` **[string][73]** Path to location on Firebase which to set
+- `files` **[Array][86]** Array of File objects to upload (usually from
+  a select-file or a drag/drop `onDrop`)
+- `dbPath` **[string][73]** Database path to place uploaded files metadata.
+- `options` **[object][70]** Options
+  - `options.name` **[string][73]** Name of the file
 
-Returns **[Promise][74]** Containing an array of File objects
+Returns **[Promise][76]** Containing an array of File objects
 
 ## deleteFile
-
 
 Delete a file from Firebase Storage with the option to
 remove its metadata in Firebase Database.
 
 ### Parameters
 
--   `path` **[string][71]** Path to location on Firebase which to set
--   `dbPath` **[string][71]** Database path to place uploaded file metadata
+- `path` **[string][73]** Path to location on Firebase which to set
+- `dbPath` **[string][73]** Database path to place uploaded file metadata
 
-Returns **[Promise][74]** Containing the File object
+Returns **[Promise][76]** Containing the File object
 
 ## watchEvent
-
 
 Watch event. **Note:** this method is used internally
 so examples have not yet been created, and it may not work as expected.
 
 ### Parameters
 
--   `type` **[string][71]** Type of watch event
--   `path` **[string][71]** Path to location on Firebase which to set listener
--   `storeAs` **[string][71]** Name of listener results within redux store
--   `options` **[object][68]** Event options object (optional, default `{}`)
-    -   `options.queryParams` **[Array][84]** List of parameters for the query
-    -   `options.queryId` **[string][71]** id of the query
+- `type` **[string][73]** Type of watch event
+- `path` **[string][73]** Path to location on Firebase which to set listener
+- `storeAs` **[string][73]** Name of listener results within redux store
+- `options` **[object][70]** Event options object (optional, default `{}`)
+  - `options.queryParams` **[Array][86]** List of parameters for the query
+  - `options.queryId` **[string][73]** id of the query
 
-Returns **([Promise][74] | void)** Results of calling watch event
+Returns **([Promise][76] | void)** Results of calling watch event
 
 ## unWatchEvent
-
 
 Unset a listener watch event. **Note:** this method is used
 internally so examples have not yet been created, and it may not work
@@ -365,12 +352,12 @@ as expected.
 
 ### Parameters
 
--   `type` **[string][71]** Type of watch event
--   `path` **[string][71]** Path to location on Firebase which to unset listener
--   `queryId` **[string][71]** Id of the listener
--   `options` **[object][68]** Event options object (optional, default `{}`)
+- `type` **[string][73]** Type of watch event
+- `path` **[string][73]** Path to location on Firebase which to unset listener
+- `queryId` **[string][73]** Id of the listener
+- `options` **[object][70]** Event options object (optional, default `{}`)
 
-Returns **void** 
+Returns **void**
 
 ## promiseEvents
 
@@ -382,71 +369,67 @@ return a Promise.
 
 ### Parameters
 
--   `watchArray` **[Array][84]** Array of objects or strings for paths to sync
-    from Firebase. Can also be a function that returns the array. The function
-    is passed the props object specified as the next parameter.
--   `options` **[object][68]** The options object that you would like to pass to
-    your watchArray generating function.
+- `watchArray` **[Array][86]** Array of objects or strings for paths to sync
+  from Firebase. Can also be a function that returns the array. The function
+  is passed the props object specified as the next parameter.
+- `options` **[object][70]** The options object that you would like to pass to
+  your watchArray generating function.
 
-Returns **[Promise][74]** Resolves with an array of watchEvent results
+Returns **[Promise][76]** Resolves with an array of watchEvent results
 
 ## login
 
-
 Logs user into Firebase. For examples, visit the
-[auth section of the docs][90] or the
-[auth recipes section][91].
+[auth section of the docs][92] or the
+[auth recipes section][93].
 
 ### Parameters
 
--   `credentials` **[object][68]** Credentials for authenticating
-    -   `credentials.provider` **[string][71]** External provider (google |
-        facebook | twitter)
-    -   `credentials.type` **[string][71]** Type of external authentication
-        (popup | redirect) (only used with provider)
-    -   `credentials.email` **[string][71]** Credentials for authenticating
-    -   `credentials.password` **[string][71]** Credentials for authenticating (only used with email)
+- `credentials` **[object][70]** Credentials for authenticating
+  - `credentials.provider` **[string][73]** External provider (google |
+    facebook | twitter)
+  - `credentials.type` **[string][73]** Type of external authentication
+    (popup | redirect) (only used with provider)
+  - `credentials.email` **[string][73]** Credentials for authenticating
+  - `credentials.password` **[string][73]** Credentials for authenticating (only used with email)
 
-Returns **[Promise][74]** Containing user's auth data
+Returns **[Promise][76]** Containing user's auth data
 
 ## reauthenticate
 
-
 Reauthenticate user into Firebase. For examples, visit the
-[auth section of the docs][90] or the
-[auth recipes section][91].
+[auth section of the docs][92] or the
+[auth recipes section][93].
 
 ### Parameters
 
--   `credentials` **[object][68]** Credentials for authenticating
-    -   `credentials.provider` **[string][71]** External provider (google |
-        facebook | twitter)
-    -   `credentials.type` **[string][71]** Type of external authentication
-        (popup | redirect) (only used with provider)
+- `credentials` **[object][70]** Credentials for authenticating
+  - `credentials.provider` **[string][73]** External provider (google |
+    facebook | twitter)
+  - `credentials.type` **[string][73]** Type of external authentication
+    (popup | redirect) (only used with provider)
 
-Returns **[Promise][74]** Containing user's auth data
+Returns **[Promise][76]** Containing user's auth data
 
 ## handleRedirectResult
 
 Logs user into Firebase using external. For examples, visit the
-[auth section][92]
+[auth section][94]
 
 ### Parameters
 
--   `authData` **[object][68]** Auth data from Firebase's getRedirectResult
+- `authData` **[object][70]** Auth data from Firebase's getRedirectResult
 
-Returns **[Promise][74]** Containing user's profile
+Returns **[Promise][76]** Containing user's profile
 
 ## logout
-
 
 Logs user out of Firebase and empties firebase state from
 redux store
 
-Returns **[Promise][74]** Resolves after logout is complete
+Returns **[Promise][76]** Resolves after logout is complete
 
 ## createUser
-
 
 Creates a new user in Firebase authentication. If
 `userProfile` config option is set, user profiles will be set to this
@@ -454,50 +437,56 @@ location.
 
 ### Parameters
 
--   `credentials` **[object][68]** Credentials for authenticating
-    -   `credentials.email` **[string][71]** Credentials for authenticating
-    -   `credentials.password` **[string][71]** Credentials for authenticating (only used with email)
--   `profile` **[object][68]** Data to include within new user profile
+- `credentials` **[object][70]** Credentials for authenticating
+  - `credentials.email` **[string][73]** Credentials for authenticating
+  - `credentials.password` **[string][73]** Credentials for authenticating (only used with email)
+- `profile` **[object][70]** Data to include within new user profile
 
-Returns **[Promise][74]** Containing user's auth data
+Returns **[Promise][76]** Containing user's auth data
 
 ## resetPassword
-
 
 Sends password reset email
 
 ### Parameters
 
--   `email` **[string][71]** Email to send recovery email to
+- `email` **[string][73]** Email to send recovery email to
 
-Returns **[Promise][74]** Resolves after password reset email is sent
+Returns **[Promise][76]** Resolves after password reset email is sent
 
 ## confirmPasswordReset
-
 
 Confirm that a user's password has been reset
 
 ### Parameters
 
--   `code` **[string][71]** Password reset code to verify
--   `password` **[string][71]** New Password to confirm reset to
+- `code` **[string][73]** Password reset code to verify
+- `password` **[string][73]** New Password to confirm reset to
 
-Returns **[Promise][74]** Resolves after password reset is confirmed
+Returns **[Promise][76]** Resolves after password reset is confirmed
 
 ## verifyPasswordResetCode
-
 
 Verify that a password reset code from a password reset
 email is valid
 
 ### Parameters
 
--   `code` **[string][71]** Password reset code to verify
+- `code` **[string][73]** Password reset code to verify
 
-Returns **[Promise][74]** Containing user auth info
+Returns **[Promise][76]** Containing user auth info
+
+## applyActionCode
+
+Apply verification code
+
+### Parameters
+
+- `code` **[string][73]** Verification code
+
+Returns **[Promise][76]** Resolves on success
 
 ## updateProfile
-
 
 Update user profile on Firebase Real Time Database or
 Firestore (if `useFirestoreForProfile: true` config included).
@@ -506,67 +495,62 @@ updating profile on Firestore uses `set`.
 
 ### Parameters
 
--   `profileUpdate` **[object][68]** Profile data to place in new profile
--   `options` **[object][68]** Options object (used to change how profile
-    update occurs)
-    -   `options.useSet` **[boolean][72]** Use set with merge instead of
-        update. Setting to `false` uses update (can cause issue of profile document
-        does not exist). Note: Only used when updating profile on Firestore (optional, default `true`)
-    -   `options.merge` **[boolean][72]** Whether or not to use merge when
-        setting profile. Note: Only used when updating profile on Firestore (optional, default `true`)
+- `profileUpdate` **[object][70]** Profile data to place in new profile
+- `options` **[object][70]** Options object (used to change how profile
+  update occurs)
+  - `options.useSet` **[boolean][74]** Use set with merge instead of
+    update. Setting to `false` uses update (can cause issue of profile document
+    does not exist). Note: Only used when updating profile on Firestore (optional, default `true`)
+  - `options.merge` **[boolean][74]** Whether or not to use merge when
+    setting profile. Note: Only used when updating profile on Firestore (optional, default `true`)
 
-Returns **[Promise][74]** Returns after updating profile within database
+Returns **[Promise][76]** Returns after updating profile within database
 
 ## updateAuth
-
 
 Update Auth profile object
 
 ### Parameters
 
--   `authUpdate` **[object][68]** Update to be auth object
--   `updateInProfile` **[boolean][72]** Update in profile
+- `authUpdate` **[object][70]** Update to be auth object
+- `updateInProfile` **[boolean][74]** Update in profile
 
-Returns **[Promise][74]** Returns after updating auth profile
+Returns **[Promise][76]** Returns after updating auth profile
 
 ## updateEmail
-
 
 Update user's email
 
 ### Parameters
 
--   `newEmail` **[string][71]** Update to be auth object
--   `updateInProfile` **[boolean][72]** Update in profile
+- `newEmail` **[string][73]** Update to be auth object
+- `updateInProfile` **[boolean][74]** Update in profile
 
-Returns **[Promise][74]** Resolves after email is updated in user's auth
+Returns **[Promise][76]** Resolves after email is updated in user's auth
 
 ## reloadAuth
 
-
 Reload user's auth object. Must be authenticated.
 
-Returns **[Promise][74]** Resolves after reloading firebase auth
+Returns **[Promise][76]** Resolves after reloading firebase auth
 
 ## linkWithCredential
-
 
 Links the user account with the given credentials.
 
 ### Parameters
 
--   `credential` **firebase.auth.AuthCredential** The auth credential
+- `credential` **firebase.auth.AuthCredential** The auth credential
 
-Returns **[Promise][74]** Resolves after linking auth with a credential
+Returns **[Promise][76]** Resolves after linking auth with a credential
 
 ## actionCreators
 
-
 ### Parameters
 
--   `credential` **firebase.auth.ConfirmationResult** The auth credential
+- `credential` **firebase.auth.ConfirmationResult** The auth credential
 
-Returns **[Promise][74]** 
+Returns **[Promise][76]**
 
 ## actionCreators
 
@@ -574,7 +558,7 @@ Returns **[Promise][74]**
 
 Firebase ref function
 
-Returns **firebase.database.Reference** 
+Returns **firebase.database.Reference**
 
 ## database
 
@@ -592,10 +576,9 @@ Returns **firebase.database.Storage** Firebase storage service
 
 Firebase auth service instance including all Firebase auth methods
 
-Returns **firebase.database.Auth** 
+Returns **firebase.database.Auth**
 
 ## getFirebase
-
 
 Get internal Firebase instance with methods which are wrapped with action dispatches. Useful for
 integrations into external libraries such as redux-thunk and redux-observable.
@@ -605,10 +588,10 @@ integrations into external libraries such as redux-thunk and redux-observable.
 _redux-thunk integration_
 
 ```javascript
-import { applyMiddleware, compose, createStore } from 'redux';
-import thunk from 'redux-thunk';
-import { getFirebase } from 'react-redux-firebase';
-import makeRootReducer from './reducers';
+import { applyMiddleware, compose, createStore } from 'redux'
+import thunk from 'redux-thunk'
+import { getFirebase } from 'react-redux-firebase'
+import makeRootReducer from './reducers'
 
 const fbConfig = {} // your firebase config
 
@@ -621,226 +604,126 @@ const store = createStore(
       thunk.withExtraArgument(getFirebase)
     ])
   )
-);
+)
 // then later
 export function addTodo(newTodo) {
   return (dispatch, getState, getFirebase) => {
     const firebase = getFirebase()
-    firebase
-      .push('todos', newTodo)
-      .then(() => {
-        dispatch({ type: 'SOME_ACTION' })
-      })
+    firebase.push('todos', newTodo).then(() => {
+      dispatch({ type: 'SOME_ACTION' })
+    })
   }
 }
 ```
 
-Returns **[object][68]** Firebase instance with methods which dispatch redux actions
+Returns **[object][70]** Firebase instance with methods which dispatch redux actions
 
 [1]: #createfirebaseinstance
-
 [2]: #parameters
-
 [3]: #set
-
 [4]: #parameters-1
-
 [5]: #setwithmeta
-
 [6]: #parameters-2
-
 [7]: #push
-
 [8]: #parameters-3
-
 [9]: #examples
-
 [10]: #pushwithmeta
-
 [11]: #parameters-4
-
 [12]: #update
-
 [13]: #parameters-5
-
 [14]: #examples-1
-
 [15]: #updatewithmeta
-
 [16]: #parameters-6
-
 [17]: #remove
-
 [18]: #parameters-7
-
 [19]: #examples-2
-
 [20]: #uniqueset
-
 [21]: #parameters-8
-
 [22]: #examples-3
-
 [23]: #uploadfile
-
 [24]: #parameters-9
-
 [25]: #uploadfiles
-
 [26]: #parameters-10
-
 [27]: #deletefile
-
 [28]: #parameters-11
-
 [29]: #watchevent
-
 [30]: #parameters-12
-
 [31]: #unwatchevent
-
 [32]: #parameters-13
-
 [33]: #promiseevents
-
 [34]: #parameters-14
-
 [35]: #login
-
 [36]: #parameters-15
-
 [37]: #reauthenticate
-
 [38]: #parameters-16
-
 [39]: #handleredirectresult
-
 [40]: #parameters-17
-
 [41]: #logout
-
 [42]: #createuser
-
 [43]: #parameters-18
-
 [44]: #resetpassword
-
 [45]: #parameters-19
-
 [46]: #confirmpasswordreset
-
 [47]: #parameters-20
-
 [48]: #verifypasswordresetcode
-
 [49]: #parameters-21
-
-[50]: #updateprofile
-
+[50]: #applyactioncode
 [51]: #parameters-22
-
-[52]: #updateauth
-
+[52]: #updateprofile
 [53]: #parameters-23
-
-[54]: #updateemail
-
+[54]: #updateauth
 [55]: #parameters-24
-
-[56]: #reloadauth
-
-[57]: #linkwithcredential
-
-[58]: #parameters-25
-
-[59]: #actioncreators
-
+[56]: #updateemail
+[57]: #parameters-25
+[58]: #reloadauth
+[59]: #linkwithcredential
 [60]: #parameters-26
+[61]: #actioncreators
+[62]: #parameters-27
+[63]: #actioncreators-1
+[64]: #ref
+[65]: #database
+[66]: #storage
+[67]: #auth
+[68]: #getfirebase
+[69]: #examples-4
+[70]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object
+[71]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function
+[72]: https://react-redux-firebase.com/docs/api/firebaseInstance.html#set
+[73]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
+[74]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean
+[75]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number
+[76]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise
+[77]: https://react-redux-firebase.com/docs/api/firebaseInstance.html#update
+[78]: https://react-redux-firebase.com/docs/api/firebaseInstance.html#push
+[79]: https://react-redux-firebase.com/docs/api/firebaseInstance.html#pushwithmeta
+[80]: https://react-redux-firebase.com/docs/api/firebaseInstance.html#updatewithmeta
+[81]: https://react-redux-firebase.com/docs/api/firebaseInstance.html#remove
+[82]: https://react-redux-firebase.com/docs/api/firebaseInstance.html#uniqueset
+[83]: https://react-redux-firebase.com/docs/api/firebaseInstance.html#uploadfile
 
-[61]: #actioncreators-1
+[84]: <>
 
-[62]: #ref
-
-[63]: #database
-
-[64]: #storage
-
-[65]: #auth
-
-[66]: #getfirebase
-
-[67]: #examples-4
-
-[68]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object
-
-[69]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function
-
-[70]: https://react-redux-firebase.com/docs/api/firebaseInstance.html#set
-
-[71]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
-
-[72]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean
-
-[73]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number
-
-[74]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise
-
-[75]: https://react-redux-firebase.com/docs/api/firebaseInstance.html#update
-
-[76]: https://react-redux-firebase.com/docs/api/firebaseInstance.html#push
-
-[77]: https://react-redux-firebase.com/docs/api/firebaseInstance.html#pushwithmeta
-
-[78]: https://react-redux-firebase.com/docs/api/firebaseInstance.html#updatewithmeta
-
-[79]: https://react-redux-firebase.com/docs/api/firebaseInstance.html#remove
-
-[80]: https://react-redux-firebase.com/docs/api/firebaseInstance.html#uniqueset
-
-[81]: https://react-redux-firebase.com/docs/api/firebaseInstance.html#uploadfile
-
-[82]: <>
-
-[83]: https://react-redux-firebase.com/docs/api/firebaseInstance.html#uploadfiles
-
-[84]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array
-
-[85]: https://react-redux-firebase.com/docs/api/firebaseInstance.html#deletefile
-
-[86]: https://react-redux-firebase.com/docs/api/firebaseInstance.html#watchevent
-
-[87]: https://react-redux-firebase.com/docs/api/firebaseInstance.html#unwatchevent
-
-[88]: https://react-redux-firebase.com/docs/auth.html#logincredentials
-
-[89]: https://react-redux-firebase.com/docs/api/firebaseInstance.html#login
-
-[90]: https://react-redux-firebase.com/docs/auth.html
-
-[91]: https://react-redux-firebase.com/docs/recipes/auth.html
-
-[92]: /docs/recipes/auth.md
-
-[93]: https://react-redux-firebase.com/docs/auth.html#logout
-
-[94]: https://react-redux-firebase.com/docs/auth.html#createuser
-
-[95]: https://react-redux-firebase.com/docs/api/firebaseInstance.html#resetpassword
-
-[96]: https://react-redux-firebase.com/docs/api/firebaseInstance.html#confirmpasswordreset
-
-[97]: https://react-redux-firebase.com/docs/api/firebaseInstance.html#verifypasswordreset
-
-[98]: https://react-redux-firebase.com/docs/api/firebaseInstance.html#updateprofile
-
-[99]: https://react-redux-firebase.com/docs/api/firebaseInstance.html#updateauth
-
-[100]: https://react-redux-firebase.com/docs/api/firebaseInstance.html#updateemail
-
-[101]: https://react-redux-firebase.com/docs/api/firebaseInstance.html#reloadauth
-
-[102]: https://react-redux-firebase.com/docs/api/firebaseInstance.html#linkwithcredential
-
-[103]: https://react-redux-firebase.com/docs/api/firebaseInstance.html#signinwithphonenumber
-
-[104]: http://react-redux-firebase.com/api/getFirebase.html
+[85]: https://react-redux-firebase.com/docs/api/firebaseInstance.html#uploadfiles
+[86]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array
+[87]: https://react-redux-firebase.com/docs/api/firebaseInstance.html#deletefile
+[88]: https://react-redux-firebase.com/docs/api/firebaseInstance.html#watchevent
+[89]: https://react-redux-firebase.com/docs/api/firebaseInstance.html#unwatchevent
+[90]: https://react-redux-firebase.com/docs/auth.html#logincredentials
+[91]: https://react-redux-firebase.com/docs/api/firebaseInstance.html#login
+[92]: https://react-redux-firebase.com/docs/auth.html
+[93]: https://react-redux-firebase.com/docs/recipes/auth.html
+[94]: /docs/recipes/auth.md
+[95]: https://react-redux-firebase.com/docs/auth.html#logout
+[96]: https://react-redux-firebase.com/docs/auth.html#createuser
+[97]: https://react-redux-firebase.com/docs/api/firebaseInstance.html#resetpassword
+[98]: https://react-redux-firebase.com/docs/api/firebaseInstance.html#confirmpasswordreset
+[99]: https://react-redux-firebase.com/docs/api/firebaseInstance.html#verifypasswordreset
+[100]: https://react-redux-firebase.com/docs/api/firebaseInstance.html#applyactioncode
+[101]: https://react-redux-firebase.com/docs/api/firebaseInstance.html#updateprofile
+[102]: https://react-redux-firebase.com/docs/api/firebaseInstance.html#updateauth
+[103]: https://react-redux-firebase.com/docs/api/firebaseInstance.html#updateemail
+[104]: https://react-redux-firebase.com/docs/api/firebaseInstance.html#reloadauth
+[105]: https://react-redux-firebase.com/docs/api/firebaseInstance.html#linkwithcredential
+[106]: https://react-redux-firebase.com/docs/api/firebaseInstance.html#signinwithphonenumber
+[107]: http://react-redux-firebase.com/api/getFirebase.html

--- a/docs/api/useFirebaseConnect.md
+++ b/docs/api/useFirebaseConnect.md
@@ -2,22 +2,21 @@
 
 ### Table of Contents
 
--   [useFirebaseConnect][1]
-    -   [Parameters][2]
-    -   [Examples][3]
+- [useFirebaseConnect][1]
+  - [Parameters][2]
+  - [Examples][3]
 
 ## useFirebaseConnect
-
 
 Hook that automatically listens/unListens to provided firebase paths
 using React's useEffect hook.
 
 ### Parameters
 
--   `queriesConfig` **([object][5] \| [string][6] \| [Function][7] \| [Array][8])** Object, string, or
-    array contains object or string for path to sync from Firebase or null if
-    hook doesn't need to sync. Can also be a function that returns an object,
-    a path string, or array of an object or a path string.
+- `queriesConfig` **([Function][5] \| [Array][6])** Object, string, or
+  array contains object or string for path to sync from Firebase or null if
+  hook doesn't need to sync. Can also be a function that returns an object,
+  a path string, or array of an object or a path string.
 
 ### Examples
 
@@ -30,14 +29,10 @@ import { useFirebaseConnect } from 'react-redux-firebase'
 
 export default function Todos() {
   // sync /todos from firebase into redux
-  useFirebaseConnect('todos')
+  useFirebaseConnect(['todos'])
   // Connect to redux state using selector hook
-  const todos = useSelector(state => state.firebase.data.todos)
-  return (
-    <div>
-      {JSON.stringify(todos, null, 2)}
-    </div>
-  )
+  const todos = useSelector((state) => state.firebase.data.todos)
+  return <div>{JSON.stringify(todos, null, 2)}</div>
 }
 ```
 
@@ -50,49 +45,21 @@ import { useSelector } from 'react-redux'
 import { useFirebaseConnect } from 'react-redux-firebase'
 
 export default function Post({ postId }) {
-  useFirebaseConnect(`posts/${postId}`) // sync /posts/postId from firebase into redux
-  const post = useSelector(({ firebase: { ordered: { posts } } }) => posts && posts[postId])
-  return (
-    <div>
-      {JSON.stringify(post, null, 2)}
-    </div>
+  useFirebaseConnect([`posts/${postId}`]) // sync /posts/postId from firebase into redux
+  const post = useSelector(
+    ({
+      firebase: {
+        ordered: { posts }
+      }
+    }) => posts && posts[postId]
   )
-}
-```
-
-_Data that depends on props, an array as a query_
-
-```javascript
-import React from 'react'
-import { compose } from 'redux'
-import { useSelector } from 'react-redux'
-import { useFirebaseConnect, getVal } from 'react-redux-firebase'
-
-export default function Post({ postId }) {
-  useFirebaseConnect([`posts/${postId}`], [postId]) // sync /posts/postId from firebase into redux
-  const post = useSelector(state => {
-    return state.firebase.ordered.posts && state.firebase.ordered.posts[postId]
-  })
-  return (
-    <div>
-      {JSON.stringify(post, null, 2)}
-    </div>
-  )
+  return <div>{JSON.stringify(post, null, 2)}</div>
 }
 ```
 
 [1]: #usefirebaseconnect
-
 [2]: #parameters
-
 [3]: #examples
-
 [4]: https://react-redux-firebase.com/docs/api/useFirebaseConnect.html
-
-[5]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object
-
-[6]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
-
-[7]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function
-
-[8]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array
+[5]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function
+[6]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array

--- a/docs/api/useFirestoreConnect.md
+++ b/docs/api/useFirestoreConnect.md
@@ -16,7 +16,7 @@ Populate is supported for Firestore as of v0.6.0 of redux-firestore (added
 
 ### Parameters
 
-- `queriesConfigs` **([object][6] \| [string][7] \| [Array][8] \| [Function][9])** An object, string,
+- `queriesConfigs` **([Array][6] \| [Function][7])** An object, string,
   or array of object or string for paths to sync from firestore. Can also be
   a function that returns the object, string, or array of object or string.
 
@@ -72,7 +72,5 @@ export default function TodoItem({ todoId }) {
 [3]: #examples
 [4]: https://react-redux-firebase.com/docs/api/useFirestoreConnect.html
 [5]: https://github.com/prescottprue/redux-firestore/issues/48
-[6]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object
-[7]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
-[8]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array
-[9]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function
+[6]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array
+[7]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function

--- a/docs/integrations/redux-saga.md
+++ b/docs/integrations/redux-saga.md
@@ -7,37 +7,33 @@ import { applyMiddleware, compose, createStore } from 'redux'
 import { browserHistory } from 'react-router'
 import makeRootReducer from './reducers'
 import createSagaMiddleware from 'redux-saga'
-import firebase from 'firebase/app';
-import 'firebase/database';
+import firebase from 'firebase/app'
+import 'firebase/database'
 
 const firebaseConfig = {} // firebase configuration including databaseURL
 const reduxFirebase = {
-  userProfile: 'users',
-  enableLogging: 'false'
+  userProfile: 'users'
 }
 
-firebase.initializeApp(firebaseConfig);
+firebase.initializeApp(firebaseConfig)
 
 function* helloSaga() {
   try {
     yield firebase.ref('/some/path').push({ nice: 'work!' })
-  } catch(err) {
+  } catch (err) {
     console.log('Error in saga!:', err)
   }
 }
 
 export default (initialState = {}, history) => {
-
   const sagaMiddleware = createSagaMiddleware() // create middleware
 
-  const middleware = [ sagaMiddleware ]
+  const middleware = [sagaMiddleware]
 
   const store = createStore(
     makeRootReducer(),
     {}, // initial state
-    compose(
-      applyMiddleware(...middleware)
-    )
+    compose(applyMiddleware(...middleware))
   )
 
   return store

--- a/docs/recipes/profile.md
+++ b/docs/recipes/profile.md
@@ -10,7 +10,22 @@ Include the `userProfile` parameter in config passed to react-redux-firebase:
 
 ```js
 const config = {
-  userProfile: 'users', // where profiles are stored in database
+  userProfile: 'users' // where profiles are stored in database
+}
+```
+
+Make sure to set your database rules to work with user profiles being stored under the `users` path of Real Time Database:
+
+```json
+{
+  "rules": {
+    "users": {
+      "$userId": {
+        ".read": "$userId === auth.uid",
+        ".write": "$userId === auth.uid"
+      }
+    }
+  }
 }
 ```
 
@@ -24,7 +39,7 @@ Then later `connect` (from [react-redux](https://github.com/reactjs/react-redux/
 import { useSelector } from 'react-redux'
 
 function SomeComponent() {
-  const profile = useSelector(state => state.firebase.profile)
+  const profile = useSelector((state) => state.firebase.profile)
   return <div>{JSON.stringify(profile, null, 2)}</div>
 }
 
@@ -42,13 +57,11 @@ Then later `connect` (from [react-redux](https://github.com/reactjs/react-redux/
 import { connect } from 'react-redux'
 
 // grab profile from redux with connect
-connect(
-  (state) => {
-    return {
-      profile: state.firebase.profile // profile passed as props.profile
-    }
+connect((state) => {
+  return {
+    profile: state.firebase.profile // profile passed as props.profile
   }
-)(SomeComponent) // pass component to be wrapped
+})(SomeComponent) // pass component to be wrapped
 
 // or with some shorthand:
 connect(({ firebase: { profile } }) => ({ profile }))(SomeComponent)
@@ -65,6 +78,19 @@ const config = {
 }
 ```
 
+Make sure to set your firestore rules to work with user profiles being stored under the `users` collection of Firestore:
+
+```
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /users/{userId} {
+      allow read, write: if request.auth.uid == userId;
+    }
+  }
+}
+```
+
 ## Update Profile
 
 The current users profile can be updated by using the `updateProfile` method:
@@ -78,7 +104,7 @@ import { useFirebase, isLoaded } from 'react-redux-firebase'
 
 export default function UpdateProfilePage() {
   const firebase = useFirebase()
-  const profile = useSelector(state => state.firebase.profile)
+  const profile = useSelector((state) => state.firebase.profile)
 
   function updateUserProfile() {
     return firebase.updateProfile({ role: 'admin' })
@@ -87,18 +113,10 @@ export default function UpdateProfilePage() {
   return (
     <div>
       <h2>Update User Profile</h2>
-      <span>
-        Click the button to update profile to include role parameter
-      </span>
-      <button onClick={updateUserProfile}>
-        Add Role To User
-      </button>
+      <span>Click the button to update profile to include role parameter</span>
+      <button onClick={updateUserProfile}>Add Role To User</button>
       <div>
-        {
-          isLoaded(profile)
-            ? JSON.stringify(profile, null, 2)
-            : 'Loading...'
-        }
+        {isLoaded(profile) ? JSON.stringify(profile, null, 2) : 'Loading...'}
       </div>
     </div>
   )
@@ -113,7 +131,8 @@ The way user profiles are written to the database can be modified by passing the
 // within your createStore.js or store.js file include the following config
 const config = {
   userProfile: 'users', // where profiles are stored in database
-  profileFactory: (userData, profileData, firebase) => { // how profiles are stored in database
+  profileFactory: (userData, profileData, firebase) => {
+    // how profiles are stored in database
     const { user } = userData
     return {
       email: user.email
@@ -152,9 +171,7 @@ Setting config like this:
 ```js
 const config = {
   userProfile: 'users', // where profiles are stored in database
-  profileParamsToPopulate: [
-    'contacts:users'
-  ]
+  profileParamsToPopulate: ['contacts:users']
 }
 ```
 

--- a/examples/complete/firestore/src/config.js
+++ b/examples/complete/firestore/src/config.js
@@ -9,8 +9,7 @@ export const firebase = {
 
 export const rrfConfig = {
   userProfile: 'users',
-  useFirestoreForProfile: true, // Store in Firestore instead of Real Time DB
-  enableLogging: false
+  useFirestoreForProfile: true // Store in Firestore instead of Real Time DB
 }
 
 export default { firebase, rrfConfig }

--- a/examples/complete/react-native/config.js
+++ b/examples/complete/react-native/config.js
@@ -9,8 +9,7 @@ export const firebase = {
 
 export const rrfConfig = {
   userProfile: 'users',
-  useFirestoreForProfile: true, // Store in Firestore instead of Real Time DB
-  enableLogging: false
+  useFirestoreForProfile: true // Store in Firestore instead of Real Time DB
 }
 
 export default { firebase, rrfConfig }

--- a/examples/complete/react-native/store.js
+++ b/examples/complete/react-native/store.js
@@ -15,7 +15,6 @@ export default function configureStore(initialState, history) {
     reactReduxFirebase(firebase, {
       userProfile: 'users',
       useFirestoreForProfile: true, // Store in Firestore instead of Real Time DB
-      enableLogging: false
     })
   )(createStore)
 

--- a/examples/complete/simple/src/config.js
+++ b/examples/complete/simple/src/config.js
@@ -9,8 +9,7 @@ export const firebase = {
 
 export const reduxFirebase = {
   userProfile: 'users',
-  useFirestoreForProfile: true,
-  enableLogging: false
+  useFirestoreForProfile: true
 }
 
 export default { firebase, reduxFirebase }

--- a/examples/complete/typescript/src/App.tsx
+++ b/examples/complete/typescript/src/App.tsx
@@ -9,8 +9,7 @@ import { firebase as fbConfig, reduxFirebase as rfConfig } from "./config";
 import Home from "./Home";
 import configureStore from "./store";
 
-const initialState = {};
-const store = configureStore(initialState);
+const store = configureStore();
 // Initialize Firebase instance
 firebase.initializeApp(fbConfig);
 

--- a/examples/complete/typescript/src/config.ts
+++ b/examples/complete/typescript/src/config.ts
@@ -9,8 +9,7 @@ export const firebase = {
 
 export const reduxFirebase = {
   userProfile: 'users',
-  useFirestoreForProfile: true,
-  enableLogging: false
+  useFirestoreForProfile: true
 }
 
 export default { firebase, reduxFirebase }

--- a/examples/snippets/webpack2/src/store.js
+++ b/examples/snippets/webpack2/src/store.js
@@ -8,7 +8,6 @@ export default function configureStore (initialState, history) {
     reactReduxFirebase(fbConfig,
       {
         userProfile: 'users',
-        enableLogging: false
       }
     ),
     typeof window === 'object' && typeof window.devToolsExtension !== 'undefined' ? window.devToolsExtension() : f => f

--- a/index.d.ts
+++ b/index.d.ts
@@ -443,7 +443,6 @@ export interface ReduxFirestoreQuerySetting {
    * @see https://github.com/prescottprue/redux-firestore#where
    */
   where?: WhereOptions | WhereOptions[]
-  endBefore?: FirestoreTypes.DocumentSnapshot | any | any[]
   /**
    * @see https://github.com/prescottprue/redux-firestore#orderby
    */
@@ -713,7 +712,7 @@ interface ExtendedAuthInstance {
    * @param credential - The auth credential
    * @see https://react-redux-firebase.com/docs/api/firebaseInstance.html#reloadauth
    */
-  reloadAuth: (credential?: firebase.auth.AuthCredential | any) => Promise<void>
+  reloadAuth: (credential?: AuthTypes.AuthCredential | any) => Promise<void>
 
   /**
    * Links the user account with the given credentials. Internally
@@ -1117,7 +1116,7 @@ interface ReactReduxFirebaseConfig {
   fileMetadataFactory?: (
     uploadRes: StorageTypes.UploadTaskSnapshot,
     firebase: WithFirebaseProps<ProfileType>['firebase'],
-    metadata: StorageTypes.UploadTaskSnapshot.metadata,
+    metadata: StorageTypes.FullMetadata,
     downloadURL: string
   ) => object
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -497,7 +497,7 @@ export type ReduxFirestoreQueriesFunction = (
  * @see https://github.com/prescottprue/redux-firestore#api
  */
 interface ExtendedFirestoreInstance
-  extends FirestoreTypes.FirebaseFirestore {
+  extends FirestoreTypes.FirebaseFirestore, FirestoreStatics {
   /**
    * Get data from firestore.
    * @see https://github.com/prescottprue/redux-firestore#get

--- a/index.d.ts
+++ b/index.d.ts
@@ -1087,6 +1087,9 @@ interface ReactReduxFirebaseConfig {
   dispatchOnUnsetListener: boolean
   dispatchRemoveAction: boolean
   enableEmptyAuthChanges: boolean
+  /**
+   * @deprecated
+   */ 
   enableLogging: boolean
   enableRedirectHandling: boolean
   firebaseStateName: string
@@ -1128,6 +1131,9 @@ interface ReactReduxFirebaseConfig {
  * @see https://github.com/prescottprue/redux-firestore#config-options
  */
 export interface ReduxFirestoreConfig {
+  /**
+   * @deprecated
+   */
   enableLogging: boolean
 
   helpersNamespace: string | null

--- a/index.d.ts
+++ b/index.d.ts
@@ -617,7 +617,9 @@ type Credentials =
     type: 'popup' | 'redirect'
     scopes?: string[]
   }
-  | AuthTypes.AuthCredential
+  | {
+    credential: AuthTypes.AuthCredential
+  }
   | {
     token: string
     profile: Object

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-redux-firebase",
-  "version": "3.8.1",
+  "version": "3.9.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-redux-firebase",
-  "version": "3.8.1",
+  "version": "3.9.0",
   "description": "Redux integration for Firebase. Comes with a Higher Order Components for use with React.",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/src/actions/auth.js
+++ b/src/actions/auth.js
@@ -37,19 +37,20 @@ export function unWatchUserProfile(firebase) {
     authUid,
     config: { userProfile, useFirestoreForProfile }
   } = firebase._
-  if (firebase._.profileWatch) {
-    if (useFirestoreForProfile && firebase.firestore) {
-      // Call profile onSnapshot unsubscribe stored on profileWatch
-      firebase._.profileWatch()
-    } else {
-      firebase
-        .database()
-        .ref()
-        .child(`${userProfile}/${authUid}`)
-        .off('value', firebase._.profileWatch)
-    }
-    firebase._.profileWatch = null
+  if (!firebase._.profileWatch) {
+    return
   }
+  if (useFirestoreForProfile && firebase.firestore) {
+    // Call profile onSnapshot unsubscribe stored on profileWatch
+    firebase._.profileWatch()
+  } else if (userProfile && firebase.database) {
+    firebase
+      .database()
+      .ref()
+      .child(`${userProfile}/${authUid}`)
+      .off('value', firebase._.profileWatch)
+  }
+  firebase._.profileWatch = null
 }
 
 /**

--- a/src/constants.js
+++ b/src/constants.js
@@ -115,7 +115,7 @@ export const actionTypes = {
  * @property {string|Function} sessions - `sessions` Location on Firebase where user
  * sessions are stored (only if presense is set). Often set to `'sessions'` or
  * `'userSessions'`. If a function is passed, the arguments are: `(currentUser, firebase)`.
- * @property {boolean} enableLogging - `false` Whether or not firebase
+ * @property {boolean} enableLogging - `false` (*deprecated*) Whether or not firebase
  * database logging is enabled. Providing `true` turns on error logging
  * (enabled by itself through `logErrors`).
  * @property {boolean} logErrors - `true` Whether or not to log internal

--- a/src/createFirebaseInstance.js
+++ b/src/createFirebaseInstance.js
@@ -19,11 +19,18 @@ let firebaseInstance
 export default function createFirebaseInstance(firebase, configs, dispatch) {
   /* istanbul ignore next: Logging is external */
   // Enable Logging based on config (handling instances without i.e RNFirebase)
+  // NOTE: This will be removed in a future version
   if (
+    configs &&
     configs.enableLogging &&
     firebase.database &&
     typeof firebase.database.enableLogging === 'function'
   ) {
+    /* eslint-disable no-console */
+    console.warn(
+      'The enableLogging config option is disabled and will be removed in a future version of react-redux-firebase. Enable logging as part of instance initialization.'
+    )
+    /* eslint-enable no-console */
     firebase.database.enableLogging(configs.enableLogging)
   }
 


### PR DESCRIPTION
### Description

* fix(auth): prevent throw in `logout` when database is not setup (#1042) - @ssdns
* fix(types): fix `reloadAuth` argument type and duplicate of `endBefore` (#1031) - @ MatthewDailey
* fix(types): fix argument type for `login` with credentials (#1045) - @AlexanderArvidsson
* fix(types): add back `FirestoreStatics` to `ExtendedFirestoreInstance` (#1030)
* fix(core): add deprecation message `enableLogging` config option
* chore(docs): add note about required rules for profile settings (#1049)

### Check List
If not relevant to pull request, check off as complete

- [X] All tests passing
- [X] Docs updated with any changes or examples if applicable
- [X] Added tests to ensure new feature(s) work properly

### Relevant Issues
<!-- * #1 -->

* #1030 
* #1031 
* #1045
* #1049