### PR TITLE
fix(docs): added missing ')' to end wrap of connect

### DIFF
--- a/docs/api/firestoreConnect.md
+++ b/docs/api/firestoreConnect.md
@@ -43,7 +43,7 @@ export default compose(
   firestoreConnect(() => ['todos']), // sync todos collection from Firestore into redux
   connect((state) => ({
     todosList: state.firestore.data.todos
-  })
+  }))
 )(SomeComponent)
 ```
 


### PR DESCRIPTION
The ending parentheses was missing.

### Description


### Check List
If not relevant to pull request, check off as complete

- [x] All tests passing
- [ ] Docs updated with any changes or examples if applicable
- [ ] Added tests to ensure new feature(s) work properly

### Relevant Issues
<!-- * #1 -->
