### PR TITLE
fix(docs): broken link caused by typo - #1073

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -242,7 +242,7 @@ createNewUser({
 
 Logout from Firebase and delete all data from the store (`state.firebase.data` and `state.firebase.auth` are set to `null`).
 
-Looking to preserve data on logout? [checkout the `preserve` config option](/docs/api/contants), which preserves data under the specified keys in state on logout.
+Looking to preserve data on logout? [checkout the `preserve` config option](/docs/api/constants), which preserves data under the specified keys in state on logout.
 
 ##### Examples
 


### PR DESCRIPTION
### Description
At the Auth page, logout() section, the link to the constants page is broken because an "s" is missing from the constants page link.

### Check List
If not relevant to pull request, check off as complete

- [ ] All tests passing
- [x] Docs updated with any changes or examples if applicable
- [ ] Added tests to ensure new feature(s) work properly

### Relevant Issues
<!-- * #1073  -->
